### PR TITLE
Replaced boost::shared_ptr with std::shared_ptr...

### DIFF
--- a/src/opsinputs/CxWriter.cc
+++ b/src/opsinputs/CxWriter.cc
@@ -25,8 +25,8 @@
 namespace opsinputs {
 
 CxWriter::CxWriter(ioda::ObsSpace & obsdb, const eckit::Configuration & config,
-                   boost::shared_ptr<ioda::ObsDataVector<int> > flags,
-                   boost::shared_ptr<ioda::ObsDataVector<float> > obsErrors)
+                   std::shared_ptr<ioda::ObsDataVector<int> > flags,
+                   std::shared_ptr<ioda::ObsDataVector<float> > obsErrors)
   : obsdb_(obsdb), geovars_(), flags_(std::move(flags)), obsErrors_(std::move(obsErrors))
 {
   oops::Log::trace() << "CxWriter constructor starting" << std::endl;

--- a/src/opsinputs/CxWriter.h
+++ b/src/opsinputs/CxWriter.h
@@ -8,10 +8,9 @@
 #ifndef OPSINPUTS_CXWRITER_H_
 #define OPSINPUTS_CXWRITER_H_
 
+#include <memory>
 #include <ostream>
 #include <string>
-
-#include <boost/shared_ptr.hpp>
 
 #include "ioda/ObsDataVector.h"
 #include "oops/base/Variables.h"
@@ -48,8 +47,8 @@ class CxWriter : public util::Printable, private util::ObjectCounter<CxWriter> {
   static const std::string classname() {return "opsinputs::CxWriter";}
 
   CxWriter(ioda::ObsSpace &, const eckit::Configuration &,
-           boost::shared_ptr<ioda::ObsDataVector<int> > flags,
-           boost::shared_ptr<ioda::ObsDataVector<float> > obsErrors);
+           std::shared_ptr<ioda::ObsDataVector<int> > flags,
+           std::shared_ptr<ioda::ObsDataVector<float> > obsErrors);
   ~CxWriter();
 
   void preProcess() const {}
@@ -71,8 +70,8 @@ class CxWriter : public util::Printable, private util::ObjectCounter<CxWriter> {
   ioda::ObsSpace & obsdb_;
   oops::Variables geovars_;
   oops::Variables extradiagvars_;
-  boost::shared_ptr<ioda::ObsDataVector<int>> flags_;
-  boost::shared_ptr<ioda::ObsDataVector<float>> obsErrors_;
+  std::shared_ptr<ioda::ObsDataVector<int>> flags_;
+  std::shared_ptr<ioda::ObsDataVector<float>> obsErrors_;
 
   CxWriterParameters parameters_;
 };

--- a/src/opsinputs/VarObsWriter.cc
+++ b/src/opsinputs/VarObsWriter.cc
@@ -28,8 +28,8 @@
 namespace opsinputs {
 
 VarObsWriter::VarObsWriter(ioda::ObsSpace & obsdb, const eckit::Configuration & config,
-                           boost::shared_ptr<ioda::ObsDataVector<int> > flags,
-                           boost::shared_ptr<ioda::ObsDataVector<float> > obsErrors)
+                           std::shared_ptr<ioda::ObsDataVector<int> > flags,
+                           std::shared_ptr<ioda::ObsDataVector<float> > obsErrors)
   : obsdb_(obsdb), geovars_(), flags_(std::move(flags)), obsErrors_(std::move(obsErrors))
 {
   oops::Log::trace() << "VarObsWriter constructor starting" << std::endl;

--- a/src/opsinputs/VarObsWriter.h
+++ b/src/opsinputs/VarObsWriter.h
@@ -8,10 +8,9 @@
 #ifndef OPSINPUTS_VAROBSWRITER_H_
 #define OPSINPUTS_VAROBSWRITER_H_
 
+#include <memory>
 #include <ostream>
 #include <string>
-
-#include <boost/shared_ptr.hpp>
 
 #include "ioda/ObsDataVector.h"
 #include "oops/base/Variables.h"
@@ -54,8 +53,8 @@ class VarObsWriter : public util::Printable, private util::ObjectCounter<VarObsW
   static const std::string classname() {return "opsinputs::VarObsWriter";}
 
   VarObsWriter(ioda::ObsSpace &, const eckit::Configuration &,
-               boost::shared_ptr<ioda::ObsDataVector<int> > flags,
-               boost::shared_ptr<ioda::ObsDataVector<float> > obsErrors);
+               std::shared_ptr<ioda::ObsDataVector<int> > flags,
+               std::shared_ptr<ioda::ObsDataVector<float> > obsErrors);
   ~VarObsWriter();
 
   void preProcess() const {}
@@ -77,8 +76,8 @@ class VarObsWriter : public util::Printable, private util::ObjectCounter<VarObsW
   ioda::ObsSpace & obsdb_;
   oops::Variables geovars_;
   oops::Variables extradiagvars_;
-  boost::shared_ptr<ioda::ObsDataVector<int>> flags_;
-  boost::shared_ptr<ioda::ObsDataVector<float>> obsErrors_;
+  std::shared_ptr<ioda::ObsDataVector<int>> flags_;
+  std::shared_ptr<ioda::ObsDataVector<float>> obsErrors_;
 
   VarObsWriterParameters parameters_;
 };

--- a/test/opsinputs/CxChecker.cc
+++ b/test/opsinputs/CxChecker.cc
@@ -56,8 +56,8 @@ struct CxChecker::PrintCxFileOutput {
 
 
 CxChecker::CxChecker(ioda::ObsSpace & obsdb, const eckit::Configuration & config,
-                             boost::shared_ptr<ioda::ObsDataVector<int> > flags,
-                             boost::shared_ptr<ioda::ObsDataVector<float> > obsErrors)
+                             std::shared_ptr<ioda::ObsDataVector<int> > flags,
+                             std::shared_ptr<ioda::ObsDataVector<float> > obsErrors)
   : obsdb_(obsdb), geovars_(), flags_(std::move(flags)), obsErrors_(std::move(obsErrors))
 {
   oops::Log::trace() << "CxChecker constructor starting" << std::endl;

--- a/test/opsinputs/CxChecker.h
+++ b/test/opsinputs/CxChecker.h
@@ -9,11 +9,10 @@
 #define TEST_OPSINPUTS_CXCHECKER_H_
 
 #include <map>
+#include <memory>
 #include <ostream>
 #include <string>
 #include <vector>
-
-#include <boost/shared_ptr.hpp>
 
 #include "../opsinputs/CxCheckerParameters.h"
 #include "ioda/ObsDataVector.h"
@@ -54,8 +53,8 @@ class CxChecker : public util::Printable, private util::ObjectCounter<CxChecker>
   static const std::string classname() {return "opsinputs::test::CxChecker";}
 
   CxChecker(ioda::ObsSpace &, const eckit::Configuration &,
-                boost::shared_ptr<ioda::ObsDataVector<int> > flags,
-                boost::shared_ptr<ioda::ObsDataVector<float> > obsErrors);
+                std::shared_ptr<ioda::ObsDataVector<int> > flags,
+                std::shared_ptr<ioda::ObsDataVector<float> > obsErrors);
   ~CxChecker();
 
   void preProcess() const {}
@@ -88,8 +87,8 @@ class CxChecker : public util::Printable, private util::ObjectCounter<CxChecker>
   ioda::ObsSpace & obsdb_;
   oops::Variables geovars_;
   oops::Variables extradiagvars_;
-  boost::shared_ptr<ioda::ObsDataVector<int>> flags_;
-  boost::shared_ptr<ioda::ObsDataVector<float>> obsErrors_;
+  std::shared_ptr<ioda::ObsDataVector<int>> flags_;
+  std::shared_ptr<ioda::ObsDataVector<float>> obsErrors_;
 
   CxCheckerParameters parameters_;
 };

--- a/test/opsinputs/ResetFlagsToPass.cc
+++ b/test/opsinputs/ResetFlagsToPass.cc
@@ -21,8 +21,8 @@ namespace opsinputs {
 namespace test {
 
 ResetFlagsToPass::ResetFlagsToPass(ioda::ObsSpace & obsdb, const eckit::Configuration & config,
-                                   boost::shared_ptr<ioda::ObsDataVector<int> > flags,
-                                   boost::shared_ptr<ioda::ObsDataVector<float> > /*obsErrors*/)
+                                   std::shared_ptr<ioda::ObsDataVector<int> > flags,
+                                   std::shared_ptr<ioda::ObsDataVector<float> > /*obsErrors*/)
   : obsdb_(obsdb), geovars_(), flags_(std::move(flags))
 {
   oops::Log::trace() << "ResetFlagsToPass constructor starting" << std::endl;

--- a/test/opsinputs/ResetFlagsToPass.h
+++ b/test/opsinputs/ResetFlagsToPass.h
@@ -8,11 +8,10 @@
 #ifndef TEST_OPSINPUTS_RESETFLAGSTOPASS_H_
 #define TEST_OPSINPUTS_RESETFLAGSTOPASS_H_
 
+#include <memory>
 #include <ostream>
 #include <set>
 #include <string>
-
-#include <boost/shared_ptr.hpp>
 
 #include "../opsinputs/ResetFlagsToPassParameters.h"
 #include "ioda/ObsDataVector.h"
@@ -46,8 +45,8 @@ class ResetFlagsToPass : public util::Printable, private util::ObjectCounter<Res
   static const std::string classname() {return "opsinputs::test::ResetFlagsToPass";}
 
   ResetFlagsToPass(ioda::ObsSpace &, const eckit::Configuration &,
-                   boost::shared_ptr<ioda::ObsDataVector<int> > flags,
-                   boost::shared_ptr<ioda::ObsDataVector<float> > obsErrors);
+                   std::shared_ptr<ioda::ObsDataVector<int> > flags,
+                   std::shared_ptr<ioda::ObsDataVector<float> > obsErrors);
   ~ResetFlagsToPass();
 
   void preProcess() const {}
@@ -63,7 +62,7 @@ class ResetFlagsToPass : public util::Printable, private util::ObjectCounter<Res
   ioda::ObsSpace & obsdb_;
   oops::Variables geovars_;
   oops::Variables extradiagvars_;
-  boost::shared_ptr<ioda::ObsDataVector<int>> flags_;
+  std::shared_ptr<ioda::ObsDataVector<int>> flags_;
 
   std::set<int> flagsToReset_;
 };

--- a/test/opsinputs/VarObsChecker.cc
+++ b/test/opsinputs/VarObsChecker.cc
@@ -79,8 +79,8 @@ struct VarObsChecker::PrintVarObsOutput {
 
 
 VarObsChecker::VarObsChecker(ioda::ObsSpace & obsdb, const eckit::Configuration & config,
-                             boost::shared_ptr<ioda::ObsDataVector<int> > flags,
-                             boost::shared_ptr<ioda::ObsDataVector<float> > obsErrors)
+                             std::shared_ptr<ioda::ObsDataVector<int> > flags,
+                             std::shared_ptr<ioda::ObsDataVector<float> > obsErrors)
   : obsdb_(obsdb), geovars_(), flags_(std::move(flags)), obsErrors_(std::move(obsErrors))
 {
   oops::Log::trace() << "VarObsChecker constructor starting" << std::endl;

--- a/test/opsinputs/VarObsChecker.h
+++ b/test/opsinputs/VarObsChecker.h
@@ -9,10 +9,9 @@
 #define TEST_OPSINPUTS_VAROBSCHECKER_H_
 
 #include <map>
+#include <memory>
 #include <ostream>
 #include <string>
-
-#include <boost/shared_ptr.hpp>
 
 #include "../opsinputs/VarObsCheckerParameters.h"
 #include "ioda/ObsDataVector.h"
@@ -53,8 +52,8 @@ class VarObsChecker : public util::Printable, private util::ObjectCounter<VarObs
   static const std::string classname() {return "opsinputs::test::VarObsChecker";}
 
   VarObsChecker(ioda::ObsSpace &, const eckit::Configuration &,
-                boost::shared_ptr<ioda::ObsDataVector<int> > flags,
-                boost::shared_ptr<ioda::ObsDataVector<float> > obsErrors);
+                std::shared_ptr<ioda::ObsDataVector<int> > flags,
+                std::shared_ptr<ioda::ObsDataVector<float> > obsErrors);
   ~VarObsChecker();
 
   void preProcess() const {}
@@ -81,8 +80,8 @@ class VarObsChecker : public util::Printable, private util::ObjectCounter<VarObs
   ioda::ObsSpace & obsdb_;
   oops::Variables geovars_;
   oops::Variables extradiagvars_;
-  boost::shared_ptr<ioda::ObsDataVector<int>> flags_;
-  boost::shared_ptr<ioda::ObsDataVector<float>> obsErrors_;
+  std::shared_ptr<ioda::ObsDataVector<int>> flags_;
+  std::shared_ptr<ioda::ObsDataVector<float>> obsErrors_;
 
   VarObsCheckerParameters parameters_;
 };


### PR DESCRIPTION
… in calls to the ufo::ObsFilter constructor (for compatibility with the current develop branch of ufo).