### PR TITLE
Replaced mpi::comm() with mpi::world() and parallel/mpi with mpi.

### DIFF
--- a/src/opsinputs/MPIExceptionSynchronizer.cc
+++ b/src/opsinputs/MPIExceptionSynchronizer.cc
@@ -7,7 +7,7 @@
 
 #include <exception>
 
-#include "oops/parallel/mpi/mpi.h"
+#include "oops/mpi/mpi.h"
 #include "oops/util/Logger.h"
 #include "opsinputs/MPIExceptionSynchronizer.h"
 
@@ -17,7 +17,7 @@ MPIExceptionSynchronizer::~MPIExceptionSynchronizer() {
   if (!unhealthy_ && std::uncaught_exception()) {
     unhealthy_ = 1;
     int anyUnhealthy;
-    oops::mpi::comm().allReduce(unhealthy_, anyUnhealthy, eckit::mpi::Operation::MAX);
+    oops::mpi::world().allReduce(unhealthy_, anyUnhealthy, eckit::mpi::Operation::MAX);
   }
 }
 
@@ -26,7 +26,7 @@ void MPIExceptionSynchronizer::throwIfAnyProcessHasThrown() {
     throw std::logic_error("You shouldn't call throwIfAnyProcessHasThrown() "
                            "if a previous call to this function has thrown an exception");
   int anyUnhealthy;
-  oops::mpi::comm().allReduce(unhealthy_, anyUnhealthy, eckit::mpi::Operation::MAX);
+  oops::mpi::world().allReduce(unhealthy_, anyUnhealthy, eckit::mpi::Operation::MAX);
   if (anyUnhealthy) {
     unhealthy_ = 1;
     throw std::runtime_error("An exception has been thrown by another MPI process");

--- a/src/opsinputs/MPIExceptionSynchronizer.h
+++ b/src/opsinputs/MPIExceptionSynchronizer.h
@@ -8,11 +8,6 @@
 #ifndef OPSINPUTS_MPIEXCEPTIONSYNCHRONIZER_H_
 #define OPSINPUTS_MPIEXCEPTIONSYNCHRONIZER_H_
 
-#include <exception>
-
-#include "oops/parallel/mpi/mpi.h"
-#include "oops/util/Logger.h"
-
 namespace opsinputs {
 
 /// \brief Prevents deadlocks in MPI code throwing exceptions.

--- a/src/opsinputs/VarObsWriter.cc
+++ b/src/opsinputs/VarObsWriter.cc
@@ -19,7 +19,7 @@
 #include "ioda/ObsVector.h"
 #include "oops/base/Variables.h"
 #include "oops/interface/ObsFilter.h"
-#include "oops/parallel/mpi/mpi.h"
+#include "oops/mpi/mpi.h"
 #include "oops/util/Logger.h"
 #include "opsinputs/LocalEnvironment.h"
 #include "opsinputs/VarObsWriterParameters.h"

--- a/test/opsinputs/CheckerUtils.cc
+++ b/test/opsinputs/CheckerUtils.cc
@@ -18,7 +18,7 @@
 
 #include "opsinputs/MPIExceptionSynchronizer.h"
 
-#include "oops/parallel/mpi/mpi.h"
+#include "oops/mpi/mpi.h"
 #include "oops/util/Logger.h"
 
 namespace opsinputs {
@@ -80,16 +80,16 @@ std::string runOpsPrintUtil(const char *printUtilName, const std::string &inputF
 
   char tempFileName[L_tmpnam];
   std::unique_ptr<TempFile> tempFile;
-  if (oops::mpi::comm().rank() == rootProcessRank) {
+  if (oops::mpi::world().rank() == rootProcessRank) {
     std::tmpnam(tempFileName);
     tempFile.reset(new TempFile(tempFileName));
   }
   exceptionSynchronizer.throwIfAnyProcessHasThrown();
-  oops::mpi::comm().broadcast(tempFileName, L_tmpnam, rootProcessRank);
+  oops::mpi::world().broadcast(tempFileName, L_tmpnam, rootProcessRank);
 
   // Run the OPS tool
 
-  if (oops::mpi::comm().rank() == rootProcessRank) {
+  if (oops::mpi::world().rank() == rootProcessRank) {
     const eckit::PathName inputFilePathName(inputFilePath);
     if (!inputFilePathName.exists())
       throw std::runtime_error("File '" + inputFilePathName + "' not found");
@@ -104,7 +104,7 @@ std::string runOpsPrintUtil(const char *printUtilName, const std::string &inputF
 
     const std::string cmd = "mpiexec -n 1 " + exePath + " \"" + inputFilePathName +
         "\" --all --outfile=\"" + tempFile->name() + "\"";
-    if (oops::mpi::comm().rank() == 0) {
+    if (oops::mpi::world().rank() == 0) {
       oops::Log::info() << "Running " << cmd << "\n";
       const int exitCode = std::system(cmd.c_str());
       if (exitCode != 0)
@@ -115,7 +115,7 @@ std::string runOpsPrintUtil(const char *printUtilName, const std::string &inputF
 
   exceptionSynchronizer.throwIfAnyProcessHasThrown();
   // Ensure rootProcessRank has written the file
-  oops::mpi::comm().barrier();
+  oops::mpi::world().barrier();
 
   // Read the temporary file into a string.
 
@@ -124,7 +124,7 @@ std::string runOpsPrintUtil(const char *printUtilName, const std::string &inputF
   exceptionSynchronizer.throwIfAnyProcessHasThrown();
   // Ensure all processes have read the file before rootProcessRank deletes it
   // as TempFile goes out of scope
-  oops::mpi::comm().barrier();
+  oops::mpi::world().barrier();
 
   return result;
 }

--- a/test/opsinputs/CxChecker.cc
+++ b/test/opsinputs/CxChecker.cc
@@ -25,7 +25,7 @@
 #include "ioda/ObsSpace.h"
 #include "oops/base/Variables.h"
 #include "oops/interface/ObsFilter.h"
-#include "oops/parallel/mpi/mpi.h"
+#include "oops/mpi/mpi.h"
 #include "oops/util/Logger.h"
 
 #include "ufo/filters/Variables.h"

--- a/test/opsinputs/MPIExceptionSynchronizer.h
+++ b/test/opsinputs/MPIExceptionSynchronizer.h
@@ -12,7 +12,7 @@
 
 #include "eckit/testing/Test.h"
 #include "oops/../test/TestEnvironment.h"
-#include "oops/parallel/mpi/mpi.h"
+#include "oops/mpi/mpi.h"
 #include "oops/runs/Test.h"
 #include "oops/util/Expect.h"
 #include "opsinputs/MPIExceptionSynchronizer.h"
@@ -27,13 +27,13 @@ void noException() {
   int sum;
 
   synchronizer.throwIfAnyProcessHasThrown();
-  oops::mpi::comm().allReduce(term, sum, eckit::mpi::Operation::SUM);
+  oops::mpi::world().allReduce(term, sum, eckit::mpi::Operation::SUM);
 
-  EXPECT_EQUAL(sum, oops::mpi::comm().size());
+  EXPECT_EQUAL(sum, oops::mpi::world().size());
 
   synchronizer.throwIfAnyProcessHasThrown();
   int product;
-  oops::mpi::comm().allReduce(term, product, eckit::mpi::Operation::PROD);
+  oops::mpi::world().allReduce(term, product, eckit::mpi::Operation::PROD);
 
   EXPECT_EQUAL(product, 1);
 }
@@ -43,18 +43,18 @@ void exceptionBeforeFirstMPICall() {
 
   int term = 1;
 
-  if (oops::mpi::comm().rank() == 0)
+  if (oops::mpi::world().rank() == 0)
     throw std::runtime_error("An exception in one process only");
 
   synchronizer.throwIfAnyProcessHasThrown();
   int sum;
-  oops::mpi::comm().allReduce(term, sum, eckit::mpi::Operation::SUM);
+  oops::mpi::world().allReduce(term, sum, eckit::mpi::Operation::SUM);
 
-  EXPECT_EQUAL(sum, oops::mpi::comm().size());
+  EXPECT_EQUAL(sum, oops::mpi::world().size());
 
   synchronizer.throwIfAnyProcessHasThrown();
   int product;
-  oops::mpi::comm().allReduce(term, product, eckit::mpi::Operation::PROD);
+  oops::mpi::world().allReduce(term, product, eckit::mpi::Operation::PROD);
 
   EXPECT_EQUAL(product, 1);
 }
@@ -66,16 +66,16 @@ void exceptionBeforeSecondMPICall() {
 
   synchronizer.throwIfAnyProcessHasThrown();
   int sum;
-  oops::mpi::comm().allReduce(term, sum, eckit::mpi::Operation::SUM);
+  oops::mpi::world().allReduce(term, sum, eckit::mpi::Operation::SUM);
 
-  EXPECT_EQUAL(sum, oops::mpi::comm().size());
+  EXPECT_EQUAL(sum, oops::mpi::world().size());
 
-  if (oops::mpi::comm().rank() == 0)
+  if (oops::mpi::world().rank() == 0)
     throw std::runtime_error("An exception in one process only");
 
   synchronizer.throwIfAnyProcessHasThrown();
   int product;
-  oops::mpi::comm().allReduce(term, product, eckit::mpi::Operation::PROD);
+  oops::mpi::world().allReduce(term, product, eckit::mpi::Operation::PROD);
 
   EXPECT_EQUAL(product, 1);
 }
@@ -97,6 +97,8 @@ class MPIExceptionSynchronizer : public oops::Test {
   std::string testid() const override {return "opsinputs::test::MPIExceptionSynchronizer";}
 
   void register_tests() const override {}
+
+  void clear() const override {}
 };
 
 }  // namespace test

--- a/test/opsinputs/VarObsChecker.cc
+++ b/test/opsinputs/VarObsChecker.cc
@@ -23,7 +23,7 @@
 #include "ioda/ObsSpace.h"
 #include "oops/base/Variables.h"
 #include "oops/interface/ObsFilter.h"
-#include "oops/parallel/mpi/mpi.h"
+#include "oops/mpi/mpi.h"
 #include "oops/util/Logger.h"
 
 #include "ufo/filters/Variables.h"


### PR DESCRIPTION
In https://github.com/JCSDA/oops/pull/830, `comm()` has been renamed to `world()` in `oops` and the contents of the `parallel/mpi` directory moved to `parallel`.