### PR TITLE
Added calls to the OOPS_CONCRETE_PARAMETERS macro.

### DIFF
--- a/src/opsinputs/CxWriterParameters.h
+++ b/src/opsinputs/CxWriterParameters.h
@@ -19,6 +19,8 @@ namespace opsinputs {
 
 /// \brief CxWriter options.
 class CxWriterParameters : public oops::Parameters {
+  OOPS_CONCRETE_PARAMETERS(CxWriterParameters, Parameters)
+
  public:
   /// Determines OPS verbosity.
   ///

--- a/src/opsinputs/VarObsWriterParameters.h
+++ b/src/opsinputs/VarObsWriterParameters.h
@@ -20,6 +20,8 @@ namespace opsinputs {
 
 /// \brief VarObsWriter options.
 class VarObsWriterParameters : public oops::Parameters {
+  OOPS_CONCRETE_PARAMETERS(VarObsWriterParameters, Parameters)
+
  public:
   /// Determines OPS verbosity.
   ///

--- a/test/opsinputs/CxCheckerParameters.h
+++ b/test/opsinputs/CxCheckerParameters.h
@@ -21,6 +21,8 @@ namespace opsinputs {
 
 /// \brief CxChecker options.
 class CxCheckerParameters : public oops::Parameters {
+    OOPS_CONCRETE_PARAMETERS(CxCheckerParameters, Parameters)
+
  public:
   /// Output directory for Cx files.
   ///

--- a/test/opsinputs/ResetFlagsToPassParameters.h
+++ b/test/opsinputs/ResetFlagsToPassParameters.h
@@ -17,6 +17,8 @@ namespace opsinputs {
 
 /// \brief ResetFlagsToPass filter's options.
 class ResetFlagsToPassParameters : public oops::Parameters {
+  OOPS_CONCRETE_PARAMETERS(ResetFlagsToPassParameters, Parameters)
+
  public:
   /// \brief List of QC flags (elements of ufo::QCflags) to be replaced with "pass".
   oops::Parameter<std::vector<int>> flagsToReset{"flags_to_reset", {}, this};

--- a/test/opsinputs/VarObsCheckerParameters.h
+++ b/test/opsinputs/VarObsCheckerParameters.h
@@ -22,6 +22,8 @@ namespace opsinputs {
 
 /// \brief VarObsChecker options.
 class VarObsCheckerParameters : public oops::Parameters {
+  OOPS_CONCRETE_PARAMETERS(VarObsCheckerParameters, Parameters)
+
  public:
   /// Directory containing the VarObs files.
   ///


### PR DESCRIPTION
As a result of the merge of https://github.com/JCSDA/oops/pull/790 into the `develop` branch of `oops`, it is normally necessary to call the `OOPS_CONCRETE_PARAMETERS` macro from all concrete subclasses of `Parameters`.