### PR TITLE
Removed superfluous "variables" keyword from filter configurations

### DIFF
--- a/test/testinput/001_VarField_pstar.yaml
+++ b/test/testinput/001_VarField_pstar.yaml
@@ -11,7 +11,6 @@ observations:
     # Double all observation errors: we want to check if error changes made by filters are
     # propagated to VarObs files
     - filter: BlackList
-      variables: surface_pressure
       action:
         name: inflate error
         inflation factor: 2.0

--- a/test/testinput/002_VarField_temperature_RadarZ.yaml
+++ b/test/testinput/002_VarField_temperature_RadarZ.yaml
@@ -12,7 +12,6 @@ observations:
     # Double all observation errors: we want to check if error changes made by filters are
     # propagated to VarObs files
     - filter: BlackList
-      variables: air_temperature
       action:
         name: inflate error
         inflation factor: 2.0

--- a/test/testinput/002_VarField_temperature_RadarZ_MPI_1.yaml
+++ b/test/testinput/002_VarField_temperature_RadarZ_MPI_1.yaml
@@ -12,7 +12,6 @@ observations:
     # Double all observation errors: we want to check if error changes made by filters are
     # propagated to VarObs files
     - filter: BlackList
-      variables: air_temperature
       action:
         name: inflate error
         inflation factor: 2.0

--- a/test/testinput/002_VarField_temperature_RadarZ_MPI_4.yaml
+++ b/test/testinput/002_VarField_temperature_RadarZ_MPI_4.yaml
@@ -12,7 +12,6 @@ observations:
     # Double all observation errors: we want to check if error changes made by filters are
     # propagated to VarObs files
     - filter: BlackList
-      variables: air_temperature
       action:
         name: inflate error
         inflation factor: 2.0

--- a/test/testinput/002_VarField_temperature_Surface.yaml
+++ b/test/testinput/002_VarField_temperature_Surface.yaml
@@ -11,7 +11,6 @@ observations:
     # Double all observation errors: we want to check if error changes made by filters are
     # propagated to VarObs files
     - filter: BlackList
-      variables: air_temperature
       action:
         name: inflate error
         inflation factor: 2.0

--- a/test/testinput/003_VarField_rh_Sonde.yaml
+++ b/test/testinput/003_VarField_rh_Sonde.yaml
@@ -12,7 +12,6 @@ observations:
     # Double all observation errors: we want to check if error changes made by filters are
     # propagated to VarObs files
     - filter: BlackList
-      variables: relative_humidity
       action:
         name: inflate error
         inflation factor: 2.0

--- a/test/testinput/003_VarField_rh_Surface.yaml
+++ b/test/testinput/003_VarField_rh_Surface.yaml
@@ -11,7 +11,6 @@ observations:
     # Double all observation errors: we want to check if error changes made by filters are
     # propagated to VarObs files
     - filter: BlackList
-      variables: relative_humidity
       action:
         name: inflate error
         inflation factor: 2.0

--- a/test/testinput/004_VarField_u_Sonde.yaml
+++ b/test/testinput/004_VarField_u_Sonde.yaml
@@ -12,7 +12,6 @@ observations:
     # Double all observation errors: we want to check if error changes made by filters are
     # propagated to VarObs files
     - filter: BlackList
-      variables: eastward_wind
       action:
         name: inflate error
         inflation factor: 2.0

--- a/test/testinput/004_VarField_u_Surface.yaml
+++ b/test/testinput/004_VarField_u_Surface.yaml
@@ -11,7 +11,6 @@ observations:
     # Double all observation errors: we want to check if error changes made by filters are
     # propagated to VarObs files
     - filter: BlackList
-      variables: eastward_wind
       action:
         name: inflate error
         inflation factor: 2.0

--- a/test/testinput/005_VarField_v_Sonde.yaml
+++ b/test/testinput/005_VarField_v_Sonde.yaml
@@ -12,7 +12,6 @@ observations:
     # Double all observation errors: we want to check if error changes made by filters are
     # propagated to VarObs files
     - filter: BlackList
-      variables: northward_wind
       action:
         name: inflate error
         inflation factor: 2.0

--- a/test/testinput/005_VarField_v_Surface.yaml
+++ b/test/testinput/005_VarField_v_Surface.yaml
@@ -11,7 +11,6 @@ observations:
     # Double all observation errors: we want to check if error changes made by filters are
     # propagated to VarObs files
     - filter: BlackList
-      variables: northward_wind
       action:
         name: inflate error
         inflation factor: 2.0

--- a/test/testinput/023_VarField_modelsurface_geoval.yaml
+++ b/test/testinput/023_VarField_modelsurface_geoval.yaml
@@ -13,7 +13,6 @@ observations:
     # Double all observation errors: we want to check if error changes made by filters are
     # propagated to VarObs files
     - filter: BlackList
-      variables: air_temperature
       action:
         name: inflate error
         inflation factor: 2.0

--- a/test/testinput/054_VarField_numchans.yaml
+++ b/test/testinput/054_VarField_numchans.yaml
@@ -12,7 +12,6 @@ observations:
     # Double all observation errors: we want to check if error changes made by filters are
     # propagated to VarObs files
     - filter: BlackList
-      variables: brightness_temperature
       action:
         name: inflate error
         inflation factor: 2.0

--- a/test/testinput/055_VarField_channum.yaml
+++ b/test/testinput/055_VarField_channum.yaml
@@ -12,7 +12,6 @@ observations:
     # Double all observation errors: we want to check if error changes made by filters are
     # propagated to VarObs files
     - filter: BlackList
-      variables: brightness_temperature
       action:
         name: inflate error
         inflation factor: 2.0

--- a/test/testinput/066_VarField_radarobazim.yaml
+++ b/test/testinput/066_VarField_radarobazim.yaml
@@ -12,7 +12,6 @@ observations:
     # Double all observation errors: we want to check if error changes made by filters are
     # propagated to VarObs files
     - filter: BlackList
-      variables: dummy
       action:
         name: inflate error
         inflation factor: 2.0

--- a/test/testinput/071_VarField_bendingangle.yaml
+++ b/test/testinput/071_VarField_bendingangle.yaml
@@ -12,7 +12,6 @@ observations:
     # Double all observation errors: we want to check if error changes made by filters are
     # propagated to VarObs files
     - filter: BlackList
-      variables: bending_angle
       action:
         name: inflate error
         inflation factor: 2.0

--- a/test/testinput/072_VarField_impactparam.yaml
+++ b/test/testinput/072_VarField_impactparam.yaml
@@ -12,7 +12,6 @@ observations:
     # Double all observation errors: we want to check if error changes made by filters are
     # propagated to VarObs files
     - filter: BlackList
-      variables: dummy
       action:
         name: inflate error
         inflation factor: 2.0

--- a/test/testinput/077_VarField_aod.yaml
+++ b/test/testinput/077_VarField_aod.yaml
@@ -12,7 +12,6 @@ observations:
     # Double all observation errors: we want to check if error changes made by filters are
     # propagated to VarObs files
     - filter: BlackList
-      variables: aerosol_optical_depth
       action:
         name: inflate error
         inflation factor: 2.0

--- a/test/testinput/078_VarField_theta.yaml
+++ b/test/testinput/078_VarField_theta.yaml
@@ -12,7 +12,6 @@ observations:
     # Double all observation errors: we want to check if error changes made by filters are
     # propagated to VarObs files
     - filter: BlackList
-      variables: air_potential_temperature
       action:
         name: inflate error
         inflation factor: 2.0


### PR DESCRIPTION
Recently, a PR enabling JSON Schema-based validation of YAML configuration options of UFO filters was merged into ufo (https://github.com/JCSDA-internal/ufo/pull/474). The validator found an unrecognised `variables` option in the configurations of some `BlackList` filters used in `opsinputs` tests. This PR removes this option.

(The correct name of this option is `filter variables` and its expected syntax is
```yaml
filter variables:
- name: variable_name1
- name: variable_name2
...
```
so e.g.
```yaml
variables: surface_pressure
```
could be replaced by 
```yaml
filter variables: 
- name: surface_pressure
```
However, if the `filter variables` keyword is absent, the list of filter variables is set to the list of simulated variables from the ObsSpace, which is the desired behaviour in all `BlackList` filters executed by `opsinputs` tests. So it is safe to simply remove all  lines starting with `variables:`)