### PR TITLE
Fix test failures due to recent ufo updates

### DIFF
--- a/test/testinput/001_UpperAirCxField_theta.yaml
+++ b/test/testinput/001_UpperAirCxField_theta.yaml
@@ -13,13 +13,13 @@ observations:
     # Set the flag of observations with missing values to "pass": we want to check if these
     # values are encoded correctly in the Cx file.
     - filter: Reset Flags to Pass
-      flags_to_reset: [1, 6]  # missing, Hfailed
+      flags_to_reset: [10, 15]  # missing, Hfailed
     # Reject observation 3: we want to check if it is omitted from the Cx file, as expected.
     - filter: Domain Check
       where:
       - variable:
           name: latitude@MetaData
-        minvalue: 0.
+        minvalue: 0.0
     - filter: Cx Writer
       namelist_directory: testinput/CxWriterNamelists_001_UpperAirCxField_theta
       reject_obs_with_any_variable_failing_qc: true

--- a/test/testinput/001_UpperAirCxField_theta_MPI_1.yaml
+++ b/test/testinput/001_UpperAirCxField_theta_MPI_1.yaml
@@ -13,13 +13,13 @@ observations:
     # Set the flag of observations with missing values to "pass": we want to check if these
     # values are encoded correctly in the Cx file.
     - filter: Reset Flags to Pass
-      flags_to_reset: [1, 6]  # missing, Hfailed
+      flags_to_reset: [10, 15]  # missing, Hfailed
     # Reject observation 3: we want to check if it is omitted from the Cx file, as expected.
     - filter: Domain Check
       where:
       - variable:
           name: latitude@MetaData
-        minvalue: 0.
+        minvalue: 0.0
     - filter: Cx Writer
       namelist_directory: testinput/CxWriterNamelists_001_UpperAirCxField_theta
       reject_obs_with_any_variable_failing_qc: true

--- a/test/testinput/001_UpperAirCxField_theta_MPI_4.yaml
+++ b/test/testinput/001_UpperAirCxField_theta_MPI_4.yaml
@@ -13,13 +13,13 @@ observations:
     # Set the flag of observations with missing values to "pass": we want to check if these
     # values are encoded correctly in the Cx file.
     - filter: Reset Flags to Pass
-      flags_to_reset: [1, 6]  # missing, Hfailed
+      flags_to_reset: [10, 15]  # missing, Hfailed
     # Reject observation 3: we want to check if it is omitted from the Cx file, as expected.
     - filter: Domain Check
       where:
       - variable:
           name: latitude@MetaData
-        minvalue: 0.
+        minvalue: 0.0
     - filter: Cx Writer
       namelist_directory: testinput/CxWriterNamelists_001_UpperAirCxField_theta
       reject_obs_with_any_variable_failing_qc: true

--- a/test/testinput/001_VarField_pstar.yaml
+++ b/test/testinput/001_VarField_pstar.yaml
@@ -17,13 +17,13 @@ observations:
     # Set the flag of observations with missing values to "pass": we want to check if these
     # values are encoded correctly in the VarObsFile.
     - filter: Reset Flags to Pass
-      flags_to_reset: [1, 6]  # missing, Hfailed
+      flags_to_reset: [10, 15]  # missing, Hfailed
     # Reject observation 3: we want to check if it is omitted from the VarObs file, as expected.
     - filter: Domain Check
       where:
       - variable:
           name: latitude@MetaData
-        minvalue: 0.
+        minvalue: 0.0
     - filter: VarObs Writer
       reject_obs_with_any_variable_failing_qc: true
       general_mode: debug

--- a/test/testinput/002_SurfaceCxField_pstar.yaml
+++ b/test/testinput/002_SurfaceCxField_pstar.yaml
@@ -13,13 +13,13 @@ observations:
     # Set the flag of observations with missing values to "pass": we want to check if these
     # values are encoded correctly in the Cx file.
     - filter: Reset Flags to Pass
-      flags_to_reset: [1, 6]  # missing, Hfailed
+      flags_to_reset: [10, 15]  # missing, Hfailed
     # Reject observation 3: we want to check if it is omitted from the Cx file, as expected.
     - filter: Domain Check
       where:
       - variable:
           name: latitude@MetaData
-        minvalue: 0.
+        minvalue: 0.0
     - filter: Cx Writer
       namelist_directory: testinput/CxWriterNamelists_002_SurfaceCxField_pstar
       reject_obs_with_any_variable_failing_qc: true

--- a/test/testinput/002_VarField_temperature_RadarZ.yaml
+++ b/test/testinput/002_VarField_temperature_RadarZ.yaml
@@ -18,13 +18,13 @@ observations:
     # Set the flag of observations with missing values to "pass": we want to check if these
     # values are encoded correctly in the VarObsFile.
     - filter: Reset Flags to Pass
-      flags_to_reset: [1, 6]  # missing, Hfailed
+      flags_to_reset: [10, 15]  # missing, Hfailed
     # Reject observation 3: we want to check if it is omitted from the VarObs file, as expected.
     - filter: Domain Check
       where:
       - variable:
           name: latitude@MetaData
-        minvalue: 0.
+        minvalue: 0.0
     - filter: VarObs Writer
       reject_obs_with_any_variable_failing_qc: true
       general_mode: debug

--- a/test/testinput/002_VarField_temperature_RadarZ_MPI_1.yaml
+++ b/test/testinput/002_VarField_temperature_RadarZ_MPI_1.yaml
@@ -18,13 +18,13 @@ observations:
     # Set the flag of observations with missing values to "pass": we want to check if these
     # values are encoded correctly in the VarObsFile.
     - filter: Reset Flags to Pass
-      flags_to_reset: [1, 6]  # missing, Hfailed
+      flags_to_reset: [10, 15]  # missing, Hfailed
     # Reject observation 3: we want to check if it is omitted from the VarObs file, as expected.
     - filter: Domain Check
       where:
       - variable:
           name: latitude@MetaData
-        minvalue: 0.
+        minvalue: 0.0
     - filter: VarObs Writer
       reject_obs_with_any_variable_failing_qc: true
       general_mode: debug

--- a/test/testinput/002_VarField_temperature_RadarZ_MPI_4.yaml
+++ b/test/testinput/002_VarField_temperature_RadarZ_MPI_4.yaml
@@ -18,13 +18,13 @@ observations:
     # Set the flag of observations with missing values to "pass": we want to check if these
     # values are encoded correctly in the VarObsFile.
     - filter: Reset Flags to Pass
-      flags_to_reset: [1, 6]  # missing, Hfailed
+      flags_to_reset: [10, 15]  # missing, Hfailed
     # Reject observation 3: we want to check if it is omitted from the VarObs file, as expected.
     - filter: Domain Check
       where:
       - variable:
           name: latitude@MetaData
-        minvalue: 0.
+        minvalue: 0.0
     - filter: VarObs Writer
       reject_obs_with_any_variable_failing_qc: true
       general_mode: debug

--- a/test/testinput/002_VarField_temperature_Surface.yaml
+++ b/test/testinput/002_VarField_temperature_Surface.yaml
@@ -17,13 +17,13 @@ observations:
     # Set the flag of observations with missing values to "pass": we want to check if these
     # values are encoded correctly in the VarObsFile.
     - filter: Reset Flags to Pass
-      flags_to_reset: [1, 6]  # missing, Hfailed
+      flags_to_reset: [10, 15]  # missing, Hfailed
     # Reject observation 3: we want to check if it is omitted from the VarObs file, as expected.
     - filter: Domain Check
       where:
       - variable:
           name: latitude@MetaData
-        minvalue: 0.
+        minvalue: 0.0
     - filter: VarObs Writer
       reject_obs_with_any_variable_failing_qc: true
       general_mode: debug

--- a/test/testinput/003_UpperAirCxField_u.yaml
+++ b/test/testinput/003_UpperAirCxField_u.yaml
@@ -13,13 +13,13 @@ observations:
     # Set the flag of observations with missing values to "pass": we want to check if these
     # values are encoded correctly in the Cx file.
     - filter: Reset Flags to Pass
-      flags_to_reset: [1, 6]  # missing, Hfailed
+      flags_to_reset: [10, 15]  # missing, Hfailed
     # Reject observation 3: we want to check if it is omitted from the Cx file, as expected.
     - filter: Domain Check
       where:
       - variable:
           name: latitude@MetaData
-        minvalue: 0.
+        minvalue: 0.0
     - filter: Cx Writer
       namelist_directory: testinput/CxWriterNamelists_003_UpperAirCxField_u
       reject_obs_with_any_variable_failing_qc: true

--- a/test/testinput/003_VarField_rh_Sonde.yaml
+++ b/test/testinput/003_VarField_rh_Sonde.yaml
@@ -18,13 +18,13 @@ observations:
     # Set the flag of observations with missing values to "pass": we want to check if these
     # values are encoded correctly in the VarObsFile.
     - filter: Reset Flags to Pass
-      flags_to_reset: [1, 6]  # missing, Hfailed
+      flags_to_reset: [10, 15]  # missing, Hfailed
     # Reject observation 3: we want to check if it is omitted from the VarObs file, as expected.
     - filter: Domain Check
       where:
       - variable:
           name: latitude@MetaData
-        minvalue: 0.
+        minvalue: 0.0
     - filter: VarObs Writer
       reject_obs_with_any_variable_failing_qc: true
       general_mode: debug

--- a/test/testinput/003_VarField_rh_Surface.yaml
+++ b/test/testinput/003_VarField_rh_Surface.yaml
@@ -17,13 +17,13 @@ observations:
     # Set the flag of observations with missing values to "pass": we want to check if these
     # values are encoded correctly in the VarObsFile.
     - filter: Reset Flags to Pass
-      flags_to_reset: [1, 6]  # missing, Hfailed
+      flags_to_reset: [10, 15]  # missing, Hfailed
     # Reject observation 3: we want to check if it is omitted from the VarObs file, as expected.
     - filter: Domain Check
       where:
       - variable:
           name: latitude@MetaData
-        minvalue: 0.
+        minvalue: 0.0
     - filter: VarObs Writer
       reject_obs_with_any_variable_failing_qc: true
       general_mode: debug

--- a/test/testinput/004_UpperAirCxField_v.yaml
+++ b/test/testinput/004_UpperAirCxField_v.yaml
@@ -13,13 +13,13 @@ observations:
     # Set the flag of observations with missing values to "pass": we want to check if these
     # values are encoded correctly in the Cx file.
     - filter: Reset Flags to Pass
-      flags_to_reset: [1, 6]  # missing, Hfailed
+      flags_to_reset: [10, 15]  # missing, Hfailed
     # Reject observation 3: we want to check if it is omitted from the Cx file, as expected.
     - filter: Domain Check
       where:
       - variable:
           name: latitude@MetaData
-        minvalue: 0.
+        minvalue: 0.0
     - filter: Cx Writer
       namelist_directory: testinput/CxWriterNamelists_004_UpperAirCxField_v
       reject_obs_with_any_variable_failing_qc: true

--- a/test/testinput/004_VarField_u_Sonde.yaml
+++ b/test/testinput/004_VarField_u_Sonde.yaml
@@ -18,13 +18,13 @@ observations:
     # Set the flag of observations with missing values to "pass": we want to check if these
     # values are encoded correctly in the VarObsFile.
     - filter: Reset Flags to Pass
-      flags_to_reset: [1, 6]  # missing, Hfailed
+      flags_to_reset: [10, 15]  # missing, Hfailed
     # Reject observation 3: we want to check if it is omitted from the VarObs file, as expected.
     - filter: Domain Check
       where:
       - variable:
           name: latitude@MetaData
-        minvalue: 0.
+        minvalue: 0.0
     - filter: VarObs Writer
       reject_obs_with_any_variable_failing_qc: true
       general_mode: debug

--- a/test/testinput/004_VarField_u_Surface.yaml
+++ b/test/testinput/004_VarField_u_Surface.yaml
@@ -17,13 +17,13 @@ observations:
     # Set the flag of observations with missing values to "pass": we want to check if these
     # values are encoded correctly in the VarObsFile.
     - filter: Reset Flags to Pass
-      flags_to_reset: [1, 6]  # missing, Hfailed
+      flags_to_reset: [10, 15]  # missing, Hfailed
     # Reject observation 3: we want to check if it is omitted from the VarObs file, as expected.
     - filter: Domain Check
       where:
       - variable:
           name: latitude@MetaData
-        minvalue: 0.
+        minvalue: 0.0
     - filter: VarObs Writer
       reject_obs_with_any_variable_failing_qc: true
       general_mode: debug

--- a/test/testinput/005_VarField_v_Sonde.yaml
+++ b/test/testinput/005_VarField_v_Sonde.yaml
@@ -18,13 +18,13 @@ observations:
     # Set the flag of observations with missing values to "pass": we want to check if these
     # values are encoded correctly in the VarObsFile.
     - filter: Reset Flags to Pass
-      flags_to_reset: [1, 6]  # missing, Hfailed
+      flags_to_reset: [10, 15]  # missing, Hfailed
     # Reject observation 3: we want to check if it is omitted from the VarObs file, as expected.
     - filter: Domain Check
       where:
       - variable:
           name: latitude@MetaData
-        minvalue: 0.
+        minvalue: 0.0
     - filter: VarObs Writer
       reject_obs_with_any_variable_failing_qc: true
       general_mode: debug

--- a/test/testinput/005_VarField_v_Surface.yaml
+++ b/test/testinput/005_VarField_v_Surface.yaml
@@ -17,13 +17,13 @@ observations:
     # Set the flag of observations with missing values to "pass": we want to check if these
     # values are encoded correctly in the VarObsFile.
     - filter: Reset Flags to Pass
-      flags_to_reset: [1, 6]  # missing, Hfailed
+      flags_to_reset: [10, 15]  # missing, Hfailed
     # Reject observation 3: we want to check if it is omitted from the VarObs file, as expected.
     - filter: Domain Check
       where:
       - variable:
           name: latitude@MetaData
-        minvalue: 0.
+        minvalue: 0.0
     - filter: VarObs Writer
       reject_obs_with_any_variable_failing_qc: true
       general_mode: debug

--- a/test/testinput/019_VarField_satzenith.yaml
+++ b/test/testinput/019_VarField_satzenith.yaml
@@ -11,13 +11,13 @@ observations:
     # Set the flag of observations with missing values to "pass": we want to check if these
     # values are encoded correctly in the VarObsFile.
     - filter: Reset Flags to Pass
-      flags_to_reset: [1, 6]  # missing, Hfailed
+      flags_to_reset: [10, 15]  # missing, Hfailed
     # Reject observation 3: we want to check if it is omitted from the VarObs file, as expected.
     - filter: Domain Check
       where:
       - variable:
           name: latitude@MetaData
-        minvalue: 0.
+        minvalue: 0.0
     - filter: VarObs Writer
       reject_obs_with_any_variable_failing_qc: true
       general_mode: debug

--- a/test/testinput/023_VarField_modelsurface_geoval.yaml
+++ b/test/testinput/023_VarField_modelsurface_geoval.yaml
@@ -19,13 +19,13 @@ observations:
     # Set the flag of observations with missing values to "pass": we want to check if these
     # values are encoded correctly in the VarObsFile.
     - filter: Reset Flags to Pass
-      flags_to_reset: [1, 6]  # missing, Hfailed
+      flags_to_reset: [10, 15]  # missing, Hfailed
     # Reject observation 3: we want to check if it is omitted from the VarObs file, as expected.
     - filter: Domain Check
       where:
       - variable:
           name: latitude@MetaData
-        minvalue: 0.
+        minvalue: 0.0
     - filter: VarObs Writer
       reject_obs_with_any_variable_failing_qc: true
       namelist_directory: testinput/VarObsWriterNamelists_023_VarField_modelsurface

--- a/test/testinput/028_VarField_satid.yaml
+++ b/test/testinput/028_VarField_satid.yaml
@@ -11,13 +11,13 @@ observations:
     # Set the flag of observations with missing values to "pass": we want to check if these
     # values are encoded correctly in the VarObsFile.
     - filter: Reset Flags to Pass
-      flags_to_reset: [1, 6]  # missing, Hfailed
+      flags_to_reset: [10, 15]  # missing, Hfailed
     # Reject observation 3: we want to check if it is omitted from the VarObs file, as expected.
     - filter: Domain Check
       where:
       - variable:
           name: latitude@MetaData
-        minvalue: 0.
+        minvalue: 0.0
     - filter: VarObs Writer
       reject_obs_with_any_variable_failing_qc: true
       general_mode: debug

--- a/test/testinput/031_VarField_solzenith.yaml
+++ b/test/testinput/031_VarField_solzenith.yaml
@@ -11,13 +11,13 @@ observations:
     # Set the flag of observations with missing values to "pass": we want to check if these
     # values are encoded correctly in the VarObsFile.
     - filter: Reset Flags to Pass
-      flags_to_reset: [1, 6]  # missing, Hfailed
+      flags_to_reset: [10, 15]  # missing, Hfailed
     # Reject observation 3: we want to check if it is omitted from the VarObs file, as expected.
     - filter: Domain Check
       where:
       - variable:
           name: latitude@MetaData
-        minvalue: 0.
+        minvalue: 0.0
     - filter: VarObs Writer
       reject_obs_with_any_variable_failing_qc: true
       general_mode: debug

--- a/test/testinput/041-042_UpperAirCxField_dust1-dust2.yaml
+++ b/test/testinput/041-042_UpperAirCxField_dust1-dust2.yaml
@@ -16,13 +16,13 @@ observations:
     # Set the flag of observations with missing values to "pass": we want to check if these
     # values are encoded correctly in the Cx file.
     - filter: Reset Flags to Pass
-      flags_to_reset: [1, 6]  # missing, Hfailed
+      flags_to_reset: [10, 15]  # missing, Hfailed
     # Reject observation 3: we want to check if it is omitted from the Cx file, as expected.
     - filter: Domain Check
       where:
       - variable:
           name: latitude@MetaData
-        minvalue: 0.
+        minvalue: 0.0
     - filter: Cx Writer
       namelist_directory: testinput/CxWriterNamelists_041-042_UpperAirCxField_dust1-dust2
       reject_obs_with_any_variable_failing_qc: true

--- a/test/testinput/041-046_UpperAirCxField_dust1-dust6.yaml
+++ b/test/testinput/041-046_UpperAirCxField_dust1-dust6.yaml
@@ -16,13 +16,13 @@ observations:
     # Set the flag of observations with missing values to "pass": we want to check if these
     # values are encoded correctly in the Cx file.
     - filter: Reset Flags to Pass
-      flags_to_reset: [1, 6]  # missing, Hfailed
+      flags_to_reset: [10, 15]  # missing, Hfailed
     # Reject observation 3: we want to check if it is omitted from the Cx file, as expected.
     - filter: Domain Check
       where:
       - variable:
           name: latitude@MetaData
-        minvalue: 0.
+        minvalue: 0.0
     - filter: Cx Writer
       namelist_directory: testinput/CxWriterNamelists_041-046_UpperAirCxField_dust1-dust6
       reject_obs_with_any_variable_failing_qc: true

--- a/test/testinput/054_VarField_numchans.yaml
+++ b/test/testinput/054_VarField_numchans.yaml
@@ -22,7 +22,7 @@ observations:
     # Set the flag of observations with missing values to "pass": we want to check if these
     # values are encoded correctly in the VarObsFile.
     - filter: Reset Flags to Pass
-      flags_to_reset: [1, 6]  # missing, Hfailed
+      flags_to_reset: [10, 15]  # missing, Hfailed
     - filter: VarObs Writer
       namelist_directory: testinput/VarObsWriterNamelists_054_VarField_numchans
       general_mode: debug

--- a/test/testinput/055_VarField_channum.yaml
+++ b/test/testinput/055_VarField_channum.yaml
@@ -22,7 +22,7 @@ observations:
     # Set the flag of observations with missing values to "pass": we want to check if these
     # values are encoded correctly in the VarObsFile.
     - filter: Reset Flags to Pass
-      flags_to_reset: [1, 6]  # missing, Hfailed
+      flags_to_reset: [10, 15]  # missing, Hfailed
     - filter: VarObs Writer
       namelist_directory: testinput/VarObsWriterNamelists_055_VarField_channum
       general_mode: debug

--- a/test/testinput/066_VarField_radarobazim.yaml
+++ b/test/testinput/066_VarField_radarobazim.yaml
@@ -18,13 +18,13 @@ observations:
     # Set the flag of observations with missing values to "pass": we want to check if these
     # values are encoded correctly in the VarObsFile.
     - filter: Reset Flags to Pass
-      flags_to_reset: [1, 6]  # missing, Hfailed
+      flags_to_reset: [10, 15]  # missing, Hfailed
     # Reject observation 3: we want to check if it is omitted from the VarObs file, as expected.
     - filter: Domain Check
       where:
       - variable:
           name: latitude@MetaData
-        minvalue: 0.
+        minvalue: 0.0
     - filter: VarObs Writer
       reject_obs_with_any_variable_failing_qc: true
       use_radar_family: true

--- a/test/testinput/071_VarField_bendingangle.yaml
+++ b/test/testinput/071_VarField_bendingangle.yaml
@@ -18,13 +18,13 @@ observations:
     # Set the flag of observations with missing values to "pass": we want to check if these
     # values are encoded correctly in the VarObsFile.
     - filter: Reset Flags to Pass
-      flags_to_reset: [1, 6]  # missing, Hfailed
+      flags_to_reset: [10, 15]  # missing, Hfailed
     # Reject observation 3: we want to check if it is omitted from the VarObs file, as expected.
     - filter: Domain Check
       where:
       - variable:
           name: latitude@MetaData
-        minvalue: 0.
+        minvalue: 0.0
     - filter: VarObs Writer
       reject_obs_with_any_variable_failing_qc: true
       general_mode: debug

--- a/test/testinput/072_VarField_impactparam.yaml
+++ b/test/testinput/072_VarField_impactparam.yaml
@@ -18,13 +18,13 @@ observations:
     # Set the flag of observations with missing values to "pass": we want to check if these
     # values are encoded correctly in the VarObsFile.
     - filter: Reset Flags to Pass
-      flags_to_reset: [1, 6]  # missing, Hfailed
+      flags_to_reset: [10, 15]  # missing, Hfailed
     # Reject observation 3: we want to check if it is omitted from the VarObs file, as expected.
     - filter: Domain Check
       where:
       - variable:
           name: latitude@MetaData
-        minvalue: 0.
+        minvalue: 0.0
     - filter: VarObs Writer
       reject_obs_with_any_variable_failing_qc: true
       general_mode: debug

--- a/test/testinput/073_VarField_ro_rad_curv.yaml
+++ b/test/testinput/073_VarField_ro_rad_curv.yaml
@@ -11,13 +11,13 @@ observations:
     # Set the flag of observations with missing values to "pass": we want to check if these
     # values are encoded correctly in the VarObsFile.
     - filter: Reset Flags to Pass
-      flags_to_reset: [1, 6]  # missing, Hfailed
+      flags_to_reset: [10, 15]  # missing, Hfailed
     # Reject observation 3: we want to check if it is omitted from the VarObs file, as expected.
     - filter: Domain Check
       where:
       - variable:
           name: latitude@MetaData
-        minvalue: 0.
+        minvalue: 0.0
     - filter: VarObs Writer
       reject_obs_with_any_variable_failing_qc: true
       general_mode: debug

--- a/test/testinput/074_VarField_ro_geoid_und.yaml
+++ b/test/testinput/074_VarField_ro_geoid_und.yaml
@@ -11,13 +11,13 @@ observations:
     # Set the flag of observations with missing values to "pass": we want to check if these
     # values are encoded correctly in the VarObsFile.
     - filter: Reset Flags to Pass
-      flags_to_reset: [1, 6]  # missing, Hfailed
+      flags_to_reset: [10, 15]  # missing, Hfailed
     # Reject observation 3: we want to check if it is omitted from the VarObs file, as expected.
     - filter: Domain Check
       where:
       - variable:
           name: latitude@MetaData
-        minvalue: 0.
+        minvalue: 0.0
     - filter: VarObs Writer
       reject_obs_with_any_variable_failing_qc: true
       general_mode: debug

--- a/test/testinput/077_VarField_aod.yaml
+++ b/test/testinput/077_VarField_aod.yaml
@@ -18,13 +18,13 @@ observations:
     # Set the flag of observations with missing values to "pass": we want to check if these
     # values are encoded correctly in the VarObsFile.
     - filter: Reset Flags to Pass
-      flags_to_reset: [1, 6]  # missing, Hfailed
+      flags_to_reset: [10, 15]  # missing, Hfailed
     # Reject observation 3: we want to check if it is omitted from the VarObs file, as expected.
     - filter: Domain Check
       where:
       - variable:
           name: latitude@MetaData
-        minvalue: 0.
+        minvalue: 0.0
     - filter: VarObs Writer
       reject_obs_with_any_variable_failing_qc: true
       general_mode: debug

--- a/test/testinput/078_VarField_theta.yaml
+++ b/test/testinput/078_VarField_theta.yaml
@@ -18,13 +18,13 @@ observations:
     # Set the flag of observations with missing values to "pass": we want to check if these
     # values are encoded correctly in the VarObsFile.
     - filter: Reset Flags to Pass
-      flags_to_reset: [1, 6]  # missing, Hfailed
+      flags_to_reset: [10, 15]  # missing, Hfailed
     # Reject observation 3: we want to check if it is omitted from the VarObs file, as expected.
     - filter: Domain Check
       where:
       - variable:
           name: latitude@MetaData
-        minvalue: 0.
+        minvalue: 0.0
     - filter: VarObs Writer
       reject_obs_with_any_variable_failing_qc: true
       general_mode: debug

--- a/test/testinput/cxwriter_reject_obs_with_all_variables_failing_qc.yaml
+++ b/test/testinput/cxwriter_reject_obs_with_all_variables_failing_qc.yaml
@@ -21,10 +21,10 @@ observations:
       where:
       - variable:
           name: latitude@MetaData
-        minvalue: 0.
+        minvalue: 0.0
     # Set the flag of observations with missing values to "pass".
     - filter: Reset Flags to Pass
-      flags_to_reset: [1, 6]  # missing, Hfailed
+      flags_to_reset: [10, 15]  # missing, Hfailed
     - filter: Cx Writer
       namelist_directory: testinput/CxWriterNamelists_001_UpperAirCxField_theta
       reject_obs_with_all_variables_failing_qc: true

--- a/test/testinput/varobswriter_reject_obs_with_all_variables_failing_qc.yaml
+++ b/test/testinput/varobswriter_reject_obs_with_all_variables_failing_qc.yaml
@@ -19,10 +19,10 @@ observations:
       where:
       - variable:
           name: latitude@MetaData
-        minvalue: 0.
+        minvalue: 0.0
     # Set the flag of observations with missing values to "pass".
     - filter: Reset Flags to Pass
-      flags_to_reset: [1, 6]  # missing, Hfailed
+      flags_to_reset: [10, 15]  # missing, Hfailed
     - filter: VarObs Writer
       reject_obs_with_all_variables_failing_qc: true
       general_mode: debug


### PR DESCRIPTION
This PR fixes test failures caused by recent changes in ufo:
- QC flags used in YAML files are updated following their renumbering in https://github.com/JCSDA-internal/ufo/pull/1088
- all `0.` literals are replaced by `0.0`, which ensures the eckit YAML parser treats them as floating-point values and not as strings and prevents YAML validation failures. (This will no longer be necessary when we switch to a newer version of eckit, which no longer misclassifies such literals; see https://github.com/ecmwf/eckit/pull/35.)