### PR TITLE
Replace the deprecated variable NETCDF_LIBRARIES with a more modern alternative

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,9 +42,7 @@ set( OPSINPUTS_LINKER_LANGUAGE CXX )
 include_directories( ${Boost_INCLUDE_DIR} )
 
 # NetCDF
-set( NETCDF_F90 ON CACHE BOOL "Compile with Fortran NetCDF" )
-find_package( NetCDF REQUIRED )
-include_directories( ${NETCDF_INCLUDE_DIRS} )
+find_package( NetCDF REQUIRED COMPONENTS Fortran)
 
 # eckit
 find_package( eckit REQUIRED )

--- a/deps/ops/CMakeLists.txt
+++ b/deps/ops/CMakeLists.txt
@@ -123,7 +123,7 @@ target_link_libraries(ops
   ${SHUM_BYTESWAP_LIBRARY}
   ${SHUM_STRING_CONV_LIBRARY}
   ${SHUM_WGDOS_PACKING_LIBRARY}
-  ${NETCDF_LIBRARIES}
+  NetCDF::NetCDF_Fortran
 )
 
 get_target_property(OPS_Fortran_MODULE_DIRECTORY ops Fortran_MODULE_DIRECTORY)


### PR DESCRIPTION
This PR links the `ops` library to the `NetCDF::NetCDF_Fortran` CMake target. The deprecated variable `NETCDF_LIBRARIES` is no longer used.

All tests pass:
```
 1/55 Test  #1: opsinputs_coding_norms .................................................   Passed    2.59 sec
      Start  2: test_opsinputs_varobswriter_setup
 2/55 Test  #2: test_opsinputs_varobswriter_setup ......................................   Passed    0.10 sec
      Start  3: test_opsinputs_varobswriter_001_VarField_pstar
 3/55 Test  #3: test_opsinputs_varobswriter_001_VarField_pstar .........................   Passed    3.50 sec
      Start  4: test_opsinputs_varobswriter_002_VarField_temperature_Surface
 4/55 Test  #4: test_opsinputs_varobswriter_002_VarField_temperature_Surface ...........   Passed    1.18 sec
      Start  5: test_opsinputs_varobswriter_002_VarField_temperature_RadarZ
 5/55 Test  #5: test_opsinputs_varobswriter_002_VarField_temperature_RadarZ ............   Passed    1.04 sec
      Start  6: test_opsinputs_varobswriter_003_VarField_rh_Surface
 6/55 Test  #6: test_opsinputs_varobswriter_003_VarField_rh_Surface ....................   Passed    1.07 sec
      Start  7: test_opsinputs_varobswriter_003_VarField_rh_Sonde
 7/55 Test  #7: test_opsinputs_varobswriter_003_VarField_rh_Sonde ......................   Passed    1.04 sec
      Start  8: test_opsinputs_varobswriter_004_VarField_u_Surface
 8/55 Test  #8: test_opsinputs_varobswriter_004_VarField_u_Surface .....................   Passed    1.13 sec
      Start  9: test_opsinputs_varobswriter_004_VarField_u_Sonde
 9/55 Test  #9: test_opsinputs_varobswriter_004_VarField_u_Sonde .......................   Passed    1.14 sec
      Start 10: test_opsinputs_varobswriter_005_VarField_v_Surface
10/55 Test #10: test_opsinputs_varobswriter_005_VarField_v_Surface .....................   Passed    1.27 sec
      Start 11: test_opsinputs_varobswriter_005_VarField_v_Sonde
11/55 Test #11: test_opsinputs_varobswriter_005_VarField_v_Sonde .......................   Passed    1.33 sec
      Start 12: test_opsinputs_varobswriter_019_VarField_satzenith
12/55 Test #12: test_opsinputs_varobswriter_019_VarField_satzenith .....................   Passed    1.33 sec
      Start 13: test_opsinputs_varobswriter_023_VarField_modelsurface_geoval
13/55 Test #13: test_opsinputs_varobswriter_023_VarField_modelsurface_geoval ...........   Passed    1.17 sec
      Start 14: test_opsinputs_varobswriter_028_VarField_satid
14/55 Test #14: test_opsinputs_varobswriter_028_VarField_satid .........................   Passed    1.10 sec
      Start 15: test_opsinputs_varobswriter_031_VarField_solzenith
15/55 Test #15: test_opsinputs_varobswriter_031_VarField_solzenith .....................   Passed    1.18 sec
      Start 16: test_opsinputs_varobswriter_054_VarField_numchans
16/55 Test #16: test_opsinputs_varobswriter_054_VarField_numchans ......................   Passed    1.25 sec
      Start 17: test_opsinputs_varobswriter_055_VarField_channum
17/55 Test #17: test_opsinputs_varobswriter_055_VarField_channum .......................   Passed    1.19 sec
      Start 18: test_opsinputs_varobswriter_066_VarField_radarobazim
18/55 Test #18: test_opsinputs_varobswriter_066_VarField_radarobazim ...................   Passed    1.17 sec
      Start 19: test_opsinputs_varobswriter_071_VarField_bendingangle
19/55 Test #19: test_opsinputs_varobswriter_071_VarField_bendingangle ..................   Passed    1.15 sec
      Start 20: test_opsinputs_varobswriter_072_VarField_impactparam
20/55 Test #20: test_opsinputs_varobswriter_072_VarField_impactparam ...................   Passed    1.37 sec
      Start 21: test_opsinputs_varobswriter_073_VarField_ro_rad_curv
21/55 Test #21: test_opsinputs_varobswriter_073_VarField_ro_rad_curv ...................   Passed    1.18 sec
      Start 22: test_opsinputs_varobswriter_074_VarField_ro_geoid_und
22/55 Test #22: test_opsinputs_varobswriter_074_VarField_ro_geoid_und ..................   Passed    1.15 sec
      Start 23: test_opsinputs_varobswriter_077_VarField_aod
23/55 Test #23: test_opsinputs_varobswriter_077_VarField_aod ...........................   Passed    1.14 sec
      Start 24: test_opsinputs_varobswriter_078_VarField_theta
24/55 Test #24: test_opsinputs_varobswriter_078_VarField_theta .........................   Passed    1.21 sec
      Start 25: test_opsinputs_varobswriter_002_VarField_temperature_RadarZ_MPI_1
25/55 Test #25: test_opsinputs_varobswriter_002_VarField_temperature_RadarZ_MPI_1 ......   Passed    1.36 sec
      Start 26: test_opsinputs_varobswriter_002_VarField_temperature_RadarZ_MPI_4
26/55 Test #26: test_opsinputs_varobswriter_002_VarField_temperature_RadarZ_MPI_4 ......   Passed    1.46 sec
      Start 27: test_opsinputs_varobswriter_FixedHeader_VertCoord
27/55 Test #27: test_opsinputs_varobswriter_FixedHeader_VertCoord ......................   Passed    3.60 sec
      Start 28: test_opsinputs_varobswriter_FixedHeader_HorizGrid
28/55 Test #28: test_opsinputs_varobswriter_FixedHeader_HorizGrid ......................   Passed    4.48 sec
      Start 29: test_opsinputs_varobswriter_FixedHeader_GridStagger
29/55 Test #29: test_opsinputs_varobswriter_FixedHeader_GridStagger ....................   Passed    2.33 sec
      Start 30: test_opsinputs_varobswriter_FixedHeader_Times
30/55 Test #30: test_opsinputs_varobswriter_FixedHeader_Times ..........................   Passed    1.14 sec
      Start 31: test_opsinputs_varobswriter_IntegerConstants_LensAndLevels
31/55 Test #31: test_opsinputs_varobswriter_IntegerConstants_LensAndLevels .............   Passed    1.62 sec
      Start 32: test_opsinputs_varobswriter_RealConstants
32/55 Test #32: test_opsinputs_varobswriter_RealConstants ..............................   Passed    1.49 sec
      Start 33: test_opsinputs_varobswriter_reject_obs_with_all_variables_failing_qc
33/55 Test #33: test_opsinputs_varobswriter_reject_obs_with_all_variables_failing_qc ...   Passed    1.32 sec
      Start 34: test_opsinputs_varobswriter_nested_output_directory
34/55 Test #34: test_opsinputs_varobswriter_nested_output_directory ....................   Passed    1.25 sec
      Start 35: test_opsinputs_cxwriter_002_SurfaceCxField_pstar
35/55 Test #35: test_opsinputs_cxwriter_002_SurfaceCxField_pstar .......................   Passed    1.23 sec
      Start 36: test_opsinputs_cxwriter_001_UpperAirCxField_theta
36/55 Test #36: test_opsinputs_cxwriter_001_UpperAirCxField_theta ......................   Passed    1.64 sec
      Start 37: test_opsinputs_cxwriter_003_UpperAirCxField_u
37/55 Test #37: test_opsinputs_cxwriter_003_UpperAirCxField_u ..........................   Passed    1.22 sec
      Start 38: test_opsinputs_cxwriter_004_UpperAirCxField_v
38/55 Test #38: test_opsinputs_cxwriter_004_UpperAirCxField_v ..........................   Passed    1.11 sec
      Start 39: test_opsinputs_cxwriter_041-042_UpperAirCxField_dust1-dust2
39/55 Test #39: test_opsinputs_cxwriter_041-042_UpperAirCxField_dust1-dust2 ............   Passed    1.21 sec
      Start 40: test_opsinputs_cxwriter_041-046_UpperAirCxField_dust1-dust6
40/55 Test #40: test_opsinputs_cxwriter_041-046_UpperAirCxField_dust1-dust6 ............   Passed    1.30 sec
      Start 41: test_opsinputs_cxwriter_FixedHeader_VertCoord
41/55 Test #41: test_opsinputs_cxwriter_FixedHeader_VertCoord ..........................   Passed    3.88 sec
      Start 42: test_opsinputs_cxwriter_FixedHeader_HorizGrid
42/55 Test #42: test_opsinputs_cxwriter_FixedHeader_HorizGrid ..........................   Passed    4.67 sec
      Start 43: test_opsinputs_cxwriter_FixedHeader_GridStagger
43/55 Test #43: test_opsinputs_cxwriter_FixedHeader_GridStagger ........................   Passed    2.55 sec
      Start 44: test_opsinputs_cxwriter_FixedHeader_ObsFileType
44/55 Test #44: test_opsinputs_cxwriter_FixedHeader_ObsFileType ........................   Passed    3.04 sec
      Start 45: test_opsinputs_cxwriter_FixedHeader_Times
45/55 Test #45: test_opsinputs_cxwriter_FixedHeader_Times ..............................   Passed    1.25 sec
      Start 46: test_opsinputs_cxwriter_IntegerConstants_PLevels
46/55 Test #46: test_opsinputs_cxwriter_IntegerConstants_PLevels .......................   Passed    1.12 sec
      Start 47: test_opsinputs_cxwriter_RealConstants
47/55 Test #47: test_opsinputs_cxwriter_RealConstants ..................................   Passed    1.48 sec
      Start 48: test_opsinputs_cxwriter_Lookup_Times
48/55 Test #48: test_opsinputs_cxwriter_Lookup_Times ...................................   Passed    1.08 sec
      Start 49: test_opsinputs_cxwriter_Lookup_Numbers
49/55 Test #49: test_opsinputs_cxwriter_Lookup_Numbers .................................   Passed    1.48 sec
      Start 50: test_opsinputs_cxwriter_LevelDependentConstants
50/55 Test #50: test_opsinputs_cxwriter_LevelDependentConstants ........................   Passed    1.49 sec
      Start 51: test_opsinputs_cxwriter_001_UpperAirCxField_theta_MPI_1
51/55 Test #51: test_opsinputs_cxwriter_001_UpperAirCxField_theta_MPI_1 ................   Passed    1.16 sec
      Start 52: test_opsinputs_cxwriter_001_UpperAirCxField_theta_MPI_4
52/55 Test #52: test_opsinputs_cxwriter_001_UpperAirCxField_theta_MPI_4 ................   Passed    1.41 sec
      Start 53: test_opsinputs_cxwriter_reject_obs_with_all_variables_failing_qc
53/55 Test #53: test_opsinputs_cxwriter_reject_obs_with_all_variables_failing_qc .......   Passed    1.20 sec
      Start 54: test_opsinputs_cxwriter_nested_output_directory
54/55 Test #54: test_opsinputs_cxwriter_nested_output_directory ........................   Passed    1.10 sec
      Start 55: test_opsinputs_mpiexceptionsynchronizer
55/55 Test #55: test_opsinputs_mpiexceptionsynchronizer ................................   Passed    0.40 sec

100% tests passed, 0 tests failed out of 55

Label Time Summary:
executable    =   0.40 sec*proc (1 test)
mpi           =   5.80 sec*proc (5 tests)
opsinputs     =  86.05 sec*proc (55 tests)
script        =  85.65 sec*proc (54 tests)

Total Test time (real) =  86.38 sec
```