### PR TITLE
Make opsinputs filters compatible with recent changes of the ObsFilter interface

### DIFF
--- a/src/opsinputs/CxWriter.cc
+++ b/src/opsinputs/CxWriter.cc
@@ -15,7 +15,6 @@
 #include "ioda/ObsSpace.h"
 #include "ioda/ObsVector.h"
 #include "oops/base/Variables.h"
-#include "oops/interface/ObsFilter.h"
 #include "oops/util/Logger.h"
 #include "opsinputs/CxWriterParameters.h"
 #include "opsinputs/LocalEnvironment.h"
@@ -23,14 +22,13 @@
 
 namespace opsinputs {
 
-CxWriter::CxWriter(ioda::ObsSpace & obsdb, const eckit::Configuration & config,
+CxWriter::CxWriter(ioda::ObsSpace & obsdb, const Parameters_ & params,
                    std::shared_ptr<ioda::ObsDataVector<int> > flags,
                    std::shared_ptr<ioda::ObsDataVector<float> > obsErrors)
-  : obsdb_(obsdb), geovars_(), flags_(std::move(flags)), obsErrors_(std::move(obsErrors))
+  : obsdb_(obsdb), geovars_(), flags_(std::move(flags)), obsErrors_(std::move(obsErrors)),
+    parameters_(params)
 {
   oops::Log::trace() << "CxWriter constructor starting" << std::endl;
-
-  parameters_.validateAndDeserialize(config);
 
   LocalEnvironment localEnvironment;
   setupEnvironment(localEnvironment);
@@ -58,7 +56,7 @@ CxWriter::~CxWriter() {
   opsinputs_cxwriter_delete_f90(key_);
 }
 
-void CxWriter::priorFilter(const ufo::GeoVaLs & gv) const {
+void CxWriter::priorFilter(const ufo::GeoVaLs & gv) {
   oops::Log::trace() << "CxWriter priorFilter" << std::endl;
 
   LocalEnvironment localEnvironment;
@@ -67,7 +65,7 @@ void CxWriter::priorFilter(const ufo::GeoVaLs & gv) const {
   opsinputs_cxwriter_prior_f90(key_, obsdb_, gv.toFortran());
 }
 
-void CxWriter::postFilter(const ioda::ObsVector &, const ufo::ObsDiagnostics &) const {
+void CxWriter::postFilter(const ioda::ObsVector &, const ufo::ObsDiagnostics &) {
   oops::Log::trace() << "CxWriter postFilter" << std::endl;
 
   LocalEnvironment localEnvironment;
@@ -77,9 +75,7 @@ void CxWriter::postFilter(const ioda::ObsVector &, const ufo::ObsDiagnostics &) 
 }
 
 void CxWriter::print(std::ostream & os) const {
-  // To implement this, it would be best to add a print method or equivalent to Parameters.
-  // Something to think of in future.
-  os << "CxWriter::print not yet implemented " << key_;
+  os << "CxWriter: config = " << parameters_ << std::endl;
 }
 
 void CxWriter::setupEnvironment(LocalEnvironment &localEnvironment) const {

--- a/src/opsinputs/CxWriter.h
+++ b/src/opsinputs/CxWriter.h
@@ -13,10 +13,11 @@
 
 #include "ioda/ObsDataVector.h"
 #include "oops/base/Variables.h"
+#include "oops/interface/ObsFilterBase.h"
 #include "oops/util/ObjectCounter.h"
-#include "oops/util/Printable.h"
 #include "opsinputs/CxWriter.interface.h"
 #include "opsinputs/CxWriterParameters.h"
+#include "ufo/ObsTraits.h"
 
 namespace eckit {
   class Configuration;
@@ -41,24 +42,29 @@ class LocalEnvironment;
 /// Most of the implementation is in Fortran (opsinputs_cxwriter_mod.F90).
 ///
 /// \see CxWriterParameters for the list of accepted configuration parameters.
-class CxWriter : public util::Printable, private util::ObjectCounter<CxWriter> {
+class CxWriter : public oops::interface::ObsFilterBase<ufo::ObsTraits>,
+                 private util::ObjectCounter<CxWriter> {
  public:
   static const std::string classname() {return "opsinputs::CxWriter";}
 
-  CxWriter(ioda::ObsSpace &, const eckit::Configuration &,
+  /// The type of parameters accepted by the constructor of this filter.
+  /// This typedef is used by the FilterFactory.
+  typedef CxWriterParameters Parameters_;
+
+  CxWriter(ioda::ObsSpace &, const Parameters_ &,
            std::shared_ptr<ioda::ObsDataVector<int> > flags,
            std::shared_ptr<ioda::ObsDataVector<float> > obsErrors);
   ~CxWriter();
 
-  void preProcess() const {}
-  void priorFilter(const ufo::GeoVaLs &) const;
-  void postFilter(const ioda::ObsVector &, const ufo::ObsDiagnostics & diags) const;
+  void preProcess() override {}
+  void priorFilter(const ufo::GeoVaLs &) override;
+  void postFilter(const ioda::ObsVector &, const ufo::ObsDiagnostics & diags) override;
 
-  const oops::Variables & requiredVars() const {return geovars_;}
-  const oops::Variables & requiredHdiagnostics() const {return extradiagvars_;}
+  oops::Variables requiredVars() const override {return geovars_;}
+  oops::Variables requiredHdiagnostics() const override {return extradiagvars_;}
 
  private:
-  void print(std::ostream &) const;
+  void print(std::ostream &) const override;
 
   void setupEnvironment(LocalEnvironment &localEnvironment) const;
 

--- a/src/opsinputs/CxWriterParameters.h
+++ b/src/opsinputs/CxWriterParameters.h
@@ -10,7 +10,7 @@
 #include <string>
 #include <vector>
 
-#include "oops/base/ObsFilterParametersBase.h"
+#include "oops/generic/ObsFilterParametersBase.h"
 #include "oops/util/parameters/OptionalParameter.h"
 #include "oops/util/parameters/Parameter.h"
 

--- a/src/opsinputs/VarObsWriter.cc
+++ b/src/opsinputs/VarObsWriter.cc
@@ -17,7 +17,6 @@
 #include "ioda/ObsSpace.h"
 #include "ioda/ObsVector.h"
 #include "oops/base/Variables.h"
-#include "oops/interface/ObsFilter.h"
 #include "oops/mpi/mpi.h"
 #include "oops/util/Logger.h"
 #include "opsinputs/LocalEnvironment.h"
@@ -27,15 +26,13 @@
 
 namespace opsinputs {
 
-VarObsWriter::VarObsWriter(ioda::ObsSpace & obsdb, const eckit::Configuration & config,
+VarObsWriter::VarObsWriter(ioda::ObsSpace & obsdb, const Parameters_ & params,
                            std::shared_ptr<ioda::ObsDataVector<int> > flags,
                            std::shared_ptr<ioda::ObsDataVector<float> > obsErrors)
   : obsdb_(obsdb), geovars_(), extradiagvars_(), flags_(std::move(flags)),
-    obsErrors_(std::move(obsErrors))
+    obsErrors_(std::move(obsErrors)), parameters_(params)
 {
   oops::Log::trace() << "VarObsWriter constructor starting" << std::endl;
-
-  parameters_.validateAndDeserialize(config);
 
   LocalEnvironment localEnvironment;
   setupEnvironment(localEnvironment);
@@ -73,7 +70,7 @@ VarObsWriter::~VarObsWriter() {
   opsinputs_varobswriter_delete_f90(key_);
 }
 
-void VarObsWriter::priorFilter(const ufo::GeoVaLs & gv) const {
+void VarObsWriter::priorFilter(const ufo::GeoVaLs & gv) {
   oops::Log::trace() << "VarObsWriter priorFilter" << std::endl;
 
   LocalEnvironment localEnvironment;
@@ -83,7 +80,7 @@ void VarObsWriter::priorFilter(const ufo::GeoVaLs & gv) const {
 }
 
 void VarObsWriter::postFilter(const ioda::ObsVector & hofxb,
-                              const ufo::ObsDiagnostics & obsdiags) const {
+                              const ufo::ObsDiagnostics & obsdiags) {
   oops::Log::trace() << "VarObsWriter postFilter" << std::endl;
 
   LocalEnvironment localEnvironment;
@@ -95,7 +92,7 @@ void VarObsWriter::postFilter(const ioda::ObsVector & hofxb,
 }
 
 void VarObsWriter::print(std::ostream & os) const {
-  os << "VarObsWriter::print not yet implemented " << key_;
+  os << "VarObsWriter: config = " << parameters_ << std::endl;
 }
 
 void VarObsWriter::setupEnvironment(LocalEnvironment &localEnvironment) const {

--- a/src/opsinputs/VarObsWriter.h
+++ b/src/opsinputs/VarObsWriter.h
@@ -13,10 +13,12 @@
 
 #include "ioda/ObsDataVector.h"
 #include "oops/base/Variables.h"
+#include "oops/interface/ObsFilterBase.h"
 #include "oops/util/ObjectCounter.h"
 #include "oops/util/Printable.h"
 #include "opsinputs/VarObsWriter.interface.h"
 #include "opsinputs/VarObsWriterParameters.h"
+#include "ufo/ObsTraits.h"
 
 namespace eckit {
   class Configuration;
@@ -47,24 +49,29 @@ class LocalEnvironment;
 /// Ops_WriteVarobs).
 ///
 /// \see VarObsWriterParameters for the list of accepted configuration parameters.
-class VarObsWriter : public util::Printable, private util::ObjectCounter<VarObsWriter> {
+class VarObsWriter : public oops::interface::ObsFilterBase<ufo::ObsTraits>,
+                     private util::ObjectCounter<VarObsWriter> {
  public:
   static const std::string classname() {return "opsinputs::VarObsWriter";}
 
-  VarObsWriter(ioda::ObsSpace &, const eckit::Configuration &,
+  /// The type of parameters accepted by the constructor of this filter.
+  /// This typedef is used by the FilterFactory.
+  typedef VarObsWriterParameters Parameters_;
+
+  VarObsWriter(ioda::ObsSpace &, const Parameters_ &,
                std::shared_ptr<ioda::ObsDataVector<int> > flags,
                std::shared_ptr<ioda::ObsDataVector<float> > obsErrors);
   ~VarObsWriter();
 
-  void preProcess() const {}
-  void priorFilter(const ufo::GeoVaLs &) const;
-  void postFilter(const ioda::ObsVector &, const ufo::ObsDiagnostics & diags) const;
+  void preProcess() override {}
+  void priorFilter(const ufo::GeoVaLs &) override;
+  void postFilter(const ioda::ObsVector &, const ufo::ObsDiagnostics & diags) override;
 
-  const oops::Variables & requiredVars() const {return geovars_;}
-  const oops::Variables & requiredHdiagnostics() const {return extradiagvars_;}
+  oops::Variables requiredVars() const override {return geovars_;}
+  oops::Variables requiredHdiagnostics() const override {return extradiagvars_;}
 
  private:
-  void print(std::ostream &) const;
+  void print(std::ostream &) const override;
 
   void setupEnvironment(LocalEnvironment &localEnvironment) const;
 

--- a/src/opsinputs/VarObsWriterParameters.h
+++ b/src/opsinputs/VarObsWriterParameters.h
@@ -10,7 +10,7 @@
 #include <string>
 
 #include "eckit/exception/Exceptions.h"
-#include "oops/base/ObsFilterParametersBase.h"
+#include "oops/generic/ObsFilterParametersBase.h"
 #include "oops/util/parameters/OptionalParameter.h"
 #include "oops/util/parameters/Parameter.h"
 #include "oops/util/parameters/RequiredParameter.h"

--- a/src/opsinputs/instantiateObsFilterFactory.h
+++ b/src/opsinputs/instantiateObsFilterFactory.h
@@ -7,17 +7,17 @@
 #ifndef OPSINPUTS_INSTANTIATEOBSFILTERFACTORY_H_
 #define OPSINPUTS_INSTANTIATEOBSFILTERFACTORY_H_
 
-#include "oops/interface/ObsFilter.h"
+#include "oops/interface/ObsFilterBase.h"
 #include "opsinputs/CxWriter.h"
 #include "opsinputs/VarObsWriter.h"
 
 namespace opsinputs {
 
-template<typename MODEL>
+template<typename OBS>
 void instantiateObsFilterFactory() {
-  static oops::FilterMaker<MODEL, oops::ObsFilter<MODEL, VarObsWriter> >
+  static oops::interface::FilterMaker<OBS, VarObsWriter>
     makerVarObsWriter_("VarObs Writer");
-  static oops::FilterMaker<MODEL, oops::ObsFilter<MODEL, CxWriter> >
+  static oops::interface::FilterMaker<OBS, CxWriter>
     makerCxWriter_("Cx Writer");
 }
 

--- a/test/opsinputs/CxChecker.cc
+++ b/test/opsinputs/CxChecker.cc
@@ -23,7 +23,6 @@
 #include "ioda/ObsDataVector.h"
 #include "ioda/ObsSpace.h"
 #include "oops/base/Variables.h"
-#include "oops/interface/ObsFilter.h"
 #include "oops/mpi/mpi.h"
 #include "oops/util/Logger.h"
 
@@ -54,13 +53,13 @@ struct CxChecker::PrintCxFileOutput {
 };
 
 
-CxChecker::CxChecker(ioda::ObsSpace & obsdb, const eckit::Configuration & config,
+CxChecker::CxChecker(ioda::ObsSpace & obsdb, const Parameters_ & params,
                              std::shared_ptr<ioda::ObsDataVector<int> > flags,
                              std::shared_ptr<ioda::ObsDataVector<float> > obsErrors)
-  : obsdb_(obsdb), geovars_(), flags_(std::move(flags)), obsErrors_(std::move(obsErrors))
+  : obsdb_(obsdb), geovars_(), flags_(std::move(flags)), obsErrors_(std::move(obsErrors)),
+    parameters_(params)
 {
   oops::Log::trace() << "CxChecker constructor starting" << std::endl;
-  parameters_.deserialize(config);
   ASSERT_MSG(!parameters_.expectedHeaderFields.value().empty() ||
              parameters_.expectedEtaThetaLevels.value() != boost::none ||
              parameters_.expectedEtaRhoLevels.value() != boost::none ||
@@ -75,7 +74,7 @@ CxChecker::~CxChecker() {
   oops::Log::trace() << "CxChecker destructor starting" << std::endl;
 }
 
-void CxChecker::postFilter(const ioda::ObsVector &, const ufo::ObsDiagnostics &) const {
+void CxChecker::postFilter(const ioda::ObsVector &, const ufo::ObsDiagnostics &) {
   oops::Log::trace() << "CxChecker postFilter" << std::endl;
 
   opsinputs::LocalEnvironment localEnvironment;
@@ -329,7 +328,7 @@ void CxChecker::checkMainTable(
 }
 
 void CxChecker::print(std::ostream & os) const {
-  os << "CxChecker::print not yet implemented";
+  os << "CxChecker: config = " << parameters_ << std::endl;
 }
 
 }  // namespace test

--- a/test/opsinputs/CxChecker.h
+++ b/test/opsinputs/CxChecker.h
@@ -16,8 +16,9 @@
 #include "../opsinputs/CxCheckerParameters.h"
 #include "ioda/ObsDataVector.h"
 #include "oops/base/Variables.h"
+#include "oops/interface/ObsFilterBase.h"
 #include "oops/util/ObjectCounter.h"
-#include "oops/util/Printable.h"
+#include "ufo/ObsTraits.h"
 
 namespace eckit {
   class Configuration;
@@ -47,27 +48,32 @@ namespace test {
 /// from that output.
 ///
 /// See CxCheckerParameters for a list of available options.
-class CxChecker : public util::Printable, private util::ObjectCounter<CxChecker> {
+class CxChecker : public oops::interface::ObsFilterBase<ufo::ObsTraits>,
+                  private util::ObjectCounter<CxChecker> {
  public:
   static const std::string classname() {return "opsinputs::test::CxChecker";}
 
-  CxChecker(ioda::ObsSpace &, const eckit::Configuration &,
-                std::shared_ptr<ioda::ObsDataVector<int> > flags,
-                std::shared_ptr<ioda::ObsDataVector<float> > obsErrors);
+  /// The type of parameters accepted by the constructor of this filter.
+  /// This typedef is used by the FilterFactory.
+  typedef CxCheckerParameters Parameters_;
+
+  CxChecker(ioda::ObsSpace &, const Parameters_ &,
+            std::shared_ptr<ioda::ObsDataVector<int> > flags,
+            std::shared_ptr<ioda::ObsDataVector<float> > obsErrors);
   ~CxChecker();
 
-  void preProcess() const {}
-  void priorFilter(const ufo::GeoVaLs &) const {}
-  void postFilter(const ioda::ObsVector &, const ufo::ObsDiagnostics &) const;
+  void preProcess() override {}
+  void priorFilter(const ufo::GeoVaLs &) override {}
+  void postFilter(const ioda::ObsVector &, const ufo::ObsDiagnostics &) override;
 
-  const oops::Variables & requiredVars() const {return geovars_;}
-  const oops::Variables & requiredHdiagnostics() const {return extradiagvars_;}
+  oops::Variables requiredVars() const override {return geovars_;}
+  oops::Variables requiredHdiagnostics() const override {return extradiagvars_;}
 
  private:
-  class PrintCxFileOutput;
+  struct PrintCxFileOutput;
   class MainTable;
 
-  void print(std::ostream &) const;
+  void print(std::ostream &) const override;
 
   void setupEnvironment(opsinputs::LocalEnvironment &localEnvironment) const;
 

--- a/test/opsinputs/CxCheckerParameters.h
+++ b/test/opsinputs/CxCheckerParameters.h
@@ -12,15 +12,15 @@
 #include <vector>
 
 #include "eckit/exception/Exceptions.h"
+#include "oops/generic/ObsFilterParametersBase.h"
 #include "oops/util/parameters/OptionalParameter.h"
 #include "oops/util/parameters/Parameter.h"
-#include "oops/util/parameters/Parameters.h"
 
 namespace opsinputs {
 
 /// \brief CxChecker options.
-class CxCheckerParameters : public oops::Parameters {
-    OOPS_CONCRETE_PARAMETERS(CxCheckerParameters, Parameters)
+class CxCheckerParameters : public oops::ObsFilterParametersBase {
+    OOPS_CONCRETE_PARAMETERS(CxCheckerParameters, ObsFilterParametersBase)
 
  public:
   /// Output directory for Cx files.

--- a/test/opsinputs/ResetFlagsToPass.cc
+++ b/test/opsinputs/ResetFlagsToPass.cc
@@ -11,7 +11,6 @@
 #include "ioda/ObsDataVector.h"
 #include "ioda/ObsSpace.h"
 #include "oops/base/Variables.h"
-#include "oops/interface/ObsFilter.h"
 #include "oops/util/IntSetParser.h"  // for contains()
 #include "oops/util/Logger.h"
 #include "ufo/filters/QCflags.h"
@@ -19,24 +18,22 @@
 namespace opsinputs {
 namespace test {
 
-ResetFlagsToPass::ResetFlagsToPass(ioda::ObsSpace & obsdb, const eckit::Configuration & config,
+ResetFlagsToPass::ResetFlagsToPass(ioda::ObsSpace & obsdb, const Parameters_ & params,
                                    std::shared_ptr<ioda::ObsDataVector<int> > flags,
                                    std::shared_ptr<ioda::ObsDataVector<float> > /*obsErrors*/)
-  : obsdb_(obsdb), geovars_(), flags_(std::move(flags))
+  : obsdb_(obsdb), geovars_(), flags_(std::move(flags)), parameters_(params)
 {
   oops::Log::trace() << "ResetFlagsToPass constructor starting" << std::endl;
 
-  ResetFlagsToPassParameters parameters;
-  parameters.deserialize(config);
-  flagsToReset_.insert(parameters.flagsToReset.value().begin(),
-                       parameters.flagsToReset.value().end());
+  flagsToReset_.insert(parameters_.flagsToReset.value().begin(),
+                       parameters_.flagsToReset.value().end());
 }
 
 ResetFlagsToPass::~ResetFlagsToPass() {
   oops::Log::trace() << "ResetFlagsToPass destructor starting" << std::endl;
 }
 
-void ResetFlagsToPass::postFilter(const ioda::ObsVector &, const ufo::ObsDiagnostics &) const {
+void ResetFlagsToPass::postFilter(const ioda::ObsVector &, const ufo::ObsDiagnostics &) {
   oops::Log::trace() << "ResetFlagsToPass postFilter" << std::endl;
   for (size_t v = 0; v < flags_->nvars(); ++v) {
     ioda::ObsDataRow<int> &varflags = (*flags_)[v];
@@ -47,7 +44,7 @@ void ResetFlagsToPass::postFilter(const ioda::ObsVector &, const ufo::ObsDiagnos
 }
 
 void ResetFlagsToPass::print(std::ostream & os) const {
-  os << "ResetFlagsToPass::print not yet implemented";
+  os << "ResetFlagsToPass: config = " << parameters_ << std::endl;
 }
 
 }  // namespace test

--- a/test/opsinputs/ResetFlagsToPass.h
+++ b/test/opsinputs/ResetFlagsToPass.h
@@ -15,8 +15,9 @@
 #include "../opsinputs/ResetFlagsToPassParameters.h"
 #include "ioda/ObsDataVector.h"
 #include "oops/base/Variables.h"
+#include "oops/interface/ObsFilterBase.h"
 #include "oops/util/ObjectCounter.h"
-#include "oops/util/Printable.h"
+#include "ufo/ObsTraits.h"
 
 namespace eckit {
   class Configuration;
@@ -39,29 +40,36 @@ namespace test {
 /// \brief Resets observation QC flags to 'pass'.
 ///
 /// See ResetFlagsToPassParameters for the available options.
-class ResetFlagsToPass : public util::Printable, private util::ObjectCounter<ResetFlagsToPass> {
+class ResetFlagsToPass : public oops::interface::ObsFilterBase<ufo::ObsTraits>,
+                         private util::ObjectCounter<ResetFlagsToPass> {
  public:
   static const std::string classname() {return "opsinputs::test::ResetFlagsToPass";}
 
-  ResetFlagsToPass(ioda::ObsSpace &, const eckit::Configuration &,
+  /// The type of parameters accepted by the constructor of this filter.
+  /// This typedef is used by the FilterFactory.
+  typedef ResetFlagsToPassParameters Parameters_;
+
+  ResetFlagsToPass(ioda::ObsSpace &, const Parameters_ &,
                    std::shared_ptr<ioda::ObsDataVector<int> > flags,
                    std::shared_ptr<ioda::ObsDataVector<float> > obsErrors);
   ~ResetFlagsToPass();
 
-  void preProcess() const {}
-  void priorFilter(const ufo::GeoVaLs &) const {}
-  void postFilter(const ioda::ObsVector &, const ufo::ObsDiagnostics &) const;
+  void preProcess() override {}
+  void priorFilter(const ufo::GeoVaLs &) override {}
+  void postFilter(const ioda::ObsVector &, const ufo::ObsDiagnostics &) override;
 
-  const oops::Variables & requiredVars() const {return geovars_;}
-  const oops::Variables & requiredHdiagnostics() const {return extradiagvars_;}
+  oops::Variables requiredVars() const override {return geovars_;}
+  oops::Variables requiredHdiagnostics() const override {return extradiagvars_;}
 
  private:
-  void print(std::ostream &) const;
+  void print(std::ostream &) const override;
 
   ioda::ObsSpace & obsdb_;
   oops::Variables geovars_;
   oops::Variables extradiagvars_;
   std::shared_ptr<ioda::ObsDataVector<int>> flags_;
+
+  ResetFlagsToPassParameters parameters_;
 
   std::set<int> flagsToReset_;
 };

--- a/test/opsinputs/ResetFlagsToPassParameters.h
+++ b/test/opsinputs/ResetFlagsToPassParameters.h
@@ -9,14 +9,14 @@
 
 #include <vector>
 
+#include "oops/generic/ObsFilterParametersBase.h"
 #include "oops/util/parameters/Parameter.h"
-#include "oops/util/parameters/Parameters.h"
 
 namespace opsinputs {
 
 /// \brief ResetFlagsToPass filter's options.
-class ResetFlagsToPassParameters : public oops::Parameters {
-  OOPS_CONCRETE_PARAMETERS(ResetFlagsToPassParameters, Parameters)
+class ResetFlagsToPassParameters : public oops::ObsFilterParametersBase {
+  OOPS_CONCRETE_PARAMETERS(ResetFlagsToPassParameters, ObsFilterParametersBase)
 
  public:
   /// \brief List of QC flags (elements of ufo::QCflags) to be replaced with "pass".

--- a/test/opsinputs/VarObsChecker.cc
+++ b/test/opsinputs/VarObsChecker.cc
@@ -21,7 +21,6 @@
 #include "ioda/ObsDataVector.h"
 #include "ioda/ObsSpace.h"
 #include "oops/base/Variables.h"
-#include "oops/interface/ObsFilter.h"
 #include "oops/mpi/mpi.h"
 #include "oops/util/Logger.h"
 
@@ -77,13 +76,13 @@ struct VarObsChecker::PrintVarObsOutput {
 };
 
 
-VarObsChecker::VarObsChecker(ioda::ObsSpace & obsdb, const eckit::Configuration & config,
+VarObsChecker::VarObsChecker(ioda::ObsSpace & obsdb, const Parameters_ & params,
                              std::shared_ptr<ioda::ObsDataVector<int> > flags,
                              std::shared_ptr<ioda::ObsDataVector<float> > obsErrors)
-  : obsdb_(obsdb), geovars_(), flags_(std::move(flags)), obsErrors_(std::move(obsErrors))
+  : obsdb_(obsdb), geovars_(), flags_(std::move(flags)), obsErrors_(std::move(obsErrors)),
+    parameters_(params)
 {
   oops::Log::trace() << "VarObsChecker constructor starting" << std::endl;
-  parameters_.deserialize(config);
   ASSERT_MSG(!parameters_.expectedHeaderFields.value().empty() ||
              !parameters_.expectedMainTableColumns.value().empty(),
              "No VarObs file components to check have been specified");
@@ -93,7 +92,7 @@ VarObsChecker::~VarObsChecker() {
   oops::Log::trace() << "VarObsChecker destructor starting" << std::endl;
 }
 
-void VarObsChecker::postFilter(const ioda::ObsVector &, const ufo::ObsDiagnostics &) const {
+void VarObsChecker::postFilter(const ioda::ObsVector &, const ufo::ObsDiagnostics &) {
   oops::Log::trace() << "VarObsChecker postFilter" << std::endl;
 
   opsinputs::LocalEnvironment localEnvironment;
@@ -198,7 +197,7 @@ void VarObsChecker::checkMainTable(const MainTable &mainTable) const {
 }
 
 void VarObsChecker::print(std::ostream & os) const {
-  os << "VarObsChecker::print not yet implemented";
+  os << "VarObsChecker: config = " << parameters_ << std::endl;
 }
 
 }  // namespace test

--- a/test/opsinputs/VarObsChecker.h
+++ b/test/opsinputs/VarObsChecker.h
@@ -15,8 +15,9 @@
 #include "../opsinputs/VarObsCheckerParameters.h"
 #include "ioda/ObsDataVector.h"
 #include "oops/base/Variables.h"
+#include "oops/interface/ObsFilterBase.h"
 #include "oops/util/ObjectCounter.h"
-#include "oops/util/Printable.h"
+#include "ufo/ObsTraits.h"
 
 namespace eckit {
   class Configuration;
@@ -46,27 +47,32 @@ namespace test {
 /// from that output.
 ///
 /// See VarObsCheckerParameters for a list of available options.
-class VarObsChecker : public util::Printable, private util::ObjectCounter<VarObsChecker> {
+class VarObsChecker : public oops::interface::ObsFilterBase<ufo::ObsTraits>,
+                      private util::ObjectCounter<VarObsChecker> {
  public:
   static const std::string classname() {return "opsinputs::test::VarObsChecker";}
 
-  VarObsChecker(ioda::ObsSpace &, const eckit::Configuration &,
+  /// The type of parameters accepted by the constructor of this filter.
+  /// This typedef is used by the FilterFactory.
+  typedef VarObsCheckerParameters Parameters_;
+
+  VarObsChecker(ioda::ObsSpace &, const Parameters_ &,
                 std::shared_ptr<ioda::ObsDataVector<int> > flags,
                 std::shared_ptr<ioda::ObsDataVector<float> > obsErrors);
   ~VarObsChecker();
 
-  void preProcess() const {}
-  void priorFilter(const ufo::GeoVaLs &) const {}
-  void postFilter(const ioda::ObsVector &, const ufo::ObsDiagnostics &) const;
+  void preProcess() override {}
+  void priorFilter(const ufo::GeoVaLs &) override {}
+  void postFilter(const ioda::ObsVector &, const ufo::ObsDiagnostics &) override;
 
-  const oops::Variables & requiredVars() const {return geovars_;}
-  const oops::Variables & requiredHdiagnostics() const {return extradiagvars_;}
+  oops::Variables requiredVars() const override {return geovars_;}
+  oops::Variables requiredHdiagnostics() const override {return extradiagvars_;}
 
  private:
-  class PrintVarObsOutput;
+  struct PrintVarObsOutput;
   class MainTable;
 
-  void print(std::ostream &) const;
+  void print(std::ostream &) const override;
 
   void setupEnvironment(opsinputs::LocalEnvironment &localEnvironment) const;
 

--- a/test/opsinputs/VarObsCheckerParameters.h
+++ b/test/opsinputs/VarObsCheckerParameters.h
@@ -12,16 +12,16 @@
 #include <vector>
 
 #include "eckit/exception/Exceptions.h"
+#include "oops/generic/ObsFilterParametersBase.h"
 #include "oops/util/parameters/OptionalParameter.h"
 #include "oops/util/parameters/Parameter.h"
-#include "oops/util/parameters/Parameters.h"
 #include "oops/util/parameters/RequiredParameter.h"
 
 namespace opsinputs {
 
 /// \brief VarObsChecker options.
-class VarObsCheckerParameters : public oops::Parameters {
-  OOPS_CONCRETE_PARAMETERS(VarObsCheckerParameters, Parameters)
+class VarObsCheckerParameters : public oops::ObsFilterParametersBase {
+  OOPS_CONCRETE_PARAMETERS(VarObsCheckerParameters, ObsFilterParametersBase)
 
  public:
   /// Directory containing the VarObs files.

--- a/test/opsinputs/instantiateObsFilterFactory.h
+++ b/test/opsinputs/instantiateObsFilterFactory.h
@@ -10,18 +10,18 @@
 #include "../opsinputs/CxChecker.h"
 #include "../opsinputs/ResetFlagsToPass.h"
 #include "../opsinputs/VarObsChecker.h"
-#include "oops/interface/ObsFilter.h"
+#include "oops/interface/ObsFilterBase.h"
 
 namespace opsinputs {
 namespace test {
 
-template<typename MODEL>
+template<typename OBS>
 void instantiateObsFilterFactory() {
-  static oops::FilterMaker<MODEL, oops::ObsFilter<MODEL, VarObsChecker> >
+  static oops::interface::FilterMaker<OBS, VarObsChecker>
     varObsCheckerMaker("VarObs Checker");
-  static oops::FilterMaker<MODEL, oops::ObsFilter<MODEL, CxChecker> >
+  static oops::interface::FilterMaker<OBS, CxChecker>
     cxCheckerMaker("Cx Checker");
-  static oops::FilterMaker<MODEL, oops::ObsFilter<MODEL, ResetFlagsToPass> >
+  static oops::interface::FilterMaker<OBS, ResetFlagsToPass>
     resetFlagsToPassMaker("Reset Flags to Pass");
 }
 


### PR DESCRIPTION
During this week's code sprint I refactored the `ObsFilter` interface in `oops` to mimic the design `Model` interface (https://github.com/JCSDA-internal/oops/pull/1313). This change was backward-incompatible; in particular, all filter classes need now to inherit from `oops::ObsFilterBase<OBS>` or its subclass `oops::interface::ObsFilterBase<OBS>`. This PR makes the necessary adjustments to the filter classes in `opsinputs`.

All tests pass on my machine.