### PR TITLE
Use Fortran include.

### DIFF
--- a/deps/ops/public/OpsMod_EnvUtils/OpsMod_EnvUtils.F90
+++ b/deps/ops/public/OpsMod_EnvUtils/OpsMod_EnvUtils.F90
@@ -21,12 +21,12 @@ END INTERFACE ops_set_env
 
 CONTAINS
 
-#include "ops_get_env_character.inc"
-#include "ops_get_env_character_array.inc"
-#include "ops_get_env_int.inc"
-#include "ops_env_is_false.inc"
-#include "ops_env_is_set.inc"
-#include "ops_env_is_true.inc"
-#include "ops_set_env_character.inc"
+include "ops_get_env_character.inc"
+include "ops_get_env_character_array.inc"
+include "ops_get_env_int.inc"
+include "ops_env_is_false.inc"
+include "ops_env_is_set.inc"
+include "ops_env_is_true.inc"
+include "ops_set_env_character.inc"
 
 END MODULE OpsMod_EnvUtils


### PR DESCRIPTION
When compiling on the Cray I had this failure:

/home/d03/frwd/cylc-run/JopaBundle/share/jopa-bundle/opsinputs/deps/ops/public/OpsMod_EnvUtils/OpsMod_EnvUtils.F90(25): error #5268: Extension to standard: The text exceeds right hand column allowed on the line.
# 1 "/home/d03/frwd/cylc-run/JopaBundle/share/jopa-bundle/opsinputs/deps/ops/public/OpsMod_EnvUtils/ops_get_env_character_array.inc" 1 
-------------------------------------------------------------------------------------------------------------------------------------^
compilation aborted for /home/d03/frwd/cylc-run/JopaBundle/share/jopa-bundle/opsinputs/deps/ops/public/OpsMod_EnvUtils/OpsMod_EnvUtils.F90 (code 1)
make[2]: *** [opsinputs/deps/ops/CMakeFiles/ops.dir/public/OpsMod_EnvUtils/OpsMod_EnvUtils.F90.o] Error 1
make[1]: *** [opsinputs/deps/ops/CMakeFiles/ops.dir/all] Error 2

This is a confluence of compiling with -warn errors, use of cpp #include instead of Fortran include and compiling in a directory that has a rather long path.  This fix replaces the cpp includes with Fortran includes; there is no reason to have cpp includes here as there is no pre-processor stuff in the included files.  Another option would be to remove the -warn errors for this file but I don't know how to do that sort of thing for cmake.