### PR TITLE
Replace a call to include_directories() by a call to target_include_directories()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,7 +88,6 @@ endforeach()
 ################################################################################
 
 include( opsinputs_compiler_flags )
-include_directories( ${OPSINPUTS_INCLUDE_DIRS} ${OPSINPUTS_EXTRA_INCLUDE_DIRS} )
 
 add_subdirectory( deps )
 add_subdirectory( src )

--- a/src/opsinputs/CMakeLists.txt
+++ b/src/opsinputs/CMakeLists.txt
@@ -57,3 +57,15 @@ ecbuild_add_library( TARGET   opsinputs
                      LINKER_LANGUAGE ${OPSINPUTS_LINKER_LANGUAGE}
                      PRIVATE_INCLUDES ${OPS_INCLUDE_DIR} )
 target_link_libraries( opsinputs PUBLIC ufo ioda oops PRIVATE ops )
+
+## Include paths
+target_include_directories(opsinputs PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src>
+                                            $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+
+## Fortran modules
+set(MODULE_DIR ${PROJECT_NAME}/module)
+set_target_properties(${PROJECT_NAME} PROPERTIES Fortran_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/${MODULE_DIR})
+install(DIRECTORY ${CMAKE_BINARY_DIR}/${MODULE_DIR}/ DESTINATION ${CMAKE_INSTALL_LIBDIR}/${MODULE_DIR})
+target_include_directories(${PROJECT_NAME} INTERFACE
+                            $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/${MODULE_DIR}>
+                            $<INSTALL_INTERFACE:${CMAKE_INSTALL_LIBDIR}/${MODULE_DIR}>)


### PR DESCRIPTION
This ensures the `opsinputs` include directories are added to the include path of all downstream libraries/executables that depend on `opsinputs`.

The newly added code has been copied from `ufo`. 

*Further details:*
CMake distinguishes between the include path used when compiling a target X and the include path used when compiling any targets dependent on X. The former is controlled by the `INCLUDE_DIRECTORIES` property of the target X; the latter by the `INTERFACE_INCLUDE_DIRECTORIES` property of that target. The (deprecated) `include_directories(`_dirs_`)` command causes _dirs_ to be appended to the `INCLUDE_DIRECTORIES` property of any targets defined in the current `CMakeLists.txt` file (or files included from it), but not to their `INTERFACE_INCLUDE_DIRECTORIES` property. In contrast, the `target_include_directories(`_target_ `PUBLIC` _dirs_`)` command causes _dirs_ to be appended to both properties.

All tests pass on my machine.