### PR TITLE
Swap the hard-coded logicals to the values currently used in the operational suite

### DIFF
--- a/deps/ops/stubs/OpsMod_GPSRO/OpsMod_GPSRO.f90
+++ b/deps/ops/stubs/OpsMod_GPSRO/OpsMod_GPSRO.f90
@@ -13,6 +13,6 @@ SAVE
 
 ! Public declarations:
 
-LOGICAL             :: GPSRO_TPD = .FALSE.  ! .TRUE. is TPD is turned on.
+LOGICAL             :: GPSRO_TPD = .TRUE.  ! .TRUE. is TPD is turned on.
 
 END MODULE OpsMod_GPSRO

--- a/deps/ops/stubs/OpsMod_GPSRO/OpsMod_GPSROInfo_BA.f90
+++ b/deps/ops/stubs/OpsMod_GPSRO/OpsMod_GPSROInfo_BA.f90
@@ -13,7 +13,7 @@ SAVE
 
 ! Public declarations:
 
-LOGICAL              :: GPSRO_pseudo_ops = .FALSE.  ! .TRUE. is pseudo-levels turned on.
-LOGICAL              :: GPSRO_vert_interp_ops = .FALSE.  ! .TRUE. is interp of ln(P) instead of Exner.
+LOGICAL              :: GPSRO_pseudo_ops = .TRUE.  ! .TRUE. is pseudo-levels turned on.
+LOGICAL              :: GPSRO_vert_interp_ops = .TRUE.  ! .TRUE. is interp of ln(P) instead of Exner.
 
 END MODULE OpsMod_GPSROInfo_BA


### PR DESCRIPTION
There are three hard-coded logicals for GNSS-RO in opsinputs.  These are all set to `false` whereas they are `true` in the operational suite.  Given that they are very unlikely to change within the lifetime of opsinputs, I propose to change the hard-coding to `true` (as opposed to allowing them to be specified in a yaml file.

- fixes #52 