### PR TITLE
Fix following the change in missing value and min max of where clause.

### DIFF
--- a/test/testinput/varobswriter_globalnamelist_atms.yaml
+++ b/test/testinput/varobswriter_globalnamelist_atms.yaml
@@ -14,11 +14,11 @@ observations:
     - filter: Reset Flags to Pass
       flags_to_reset: [10, 15]  # missing, Hfailed
     # Reject observation 3: we want to check if it is omitted from the VarObs file, as expected.
-    - filter: Domain Check
+    - filter: BlackList
       where:
       - variable:
           name: latitude@MetaData
-        minvalue: 0.0
+        is_not_defined:
     - filter: VarObs Writer
       namelist_directory: ../etc/global/varobs
       general_mode: debug


### PR DESCRIPTION
The global varobs atms test was failing.  Thanks to @DJDavies2 for spotting.  This was caused by the recently ufo merged change which ignores missing values when checking the min and max of a range.

I have therefore used a blacklist with is_not_defined to resolve this.