### PR TITLE
test AMSR obsgroup update

### DIFF
--- a/deps/ops/public/Ops_Constants/Ops_SubTypeNameToNum.inc
+++ b/deps/ops/public/Ops_Constants/Ops_SubTypeNameToNum.inc
@@ -45,7 +45,7 @@ SELECT CASE (name)
     num = ObsTypeALADIN
   CASE ("AMDARS")
     num = ObsTypeAmdar
-  CASE ("AMSR2")
+  CASE ("AMSR")
     num = ObsTypeAMSR2
   CASE ("AMSUB")
     num = ObsTypeAMSUB

--- a/deps/ops/public/Ops_Constants/Ops_SubTypeNumToName.inc
+++ b/deps/ops/public/Ops_Constants/Ops_SubTypeNumToName.inc
@@ -47,7 +47,7 @@ SELECT CASE (num)
   CASE (ObsTypeAmdar)
     name = "AMDARS"
   CASE (ObsTypeAMSR2)
-    name = "AMSR2"
+    name = "AMSR"
   CASE (ObsTypeAMV)
     name = "AMV"
   CASE (ObsTypeAMSUB)


### PR DESCRIPTION
This is an update of the NumToName and NameToNum routines to match the Obs space naming convention in JOPA, i.e., 'AMSR'. Without this change, the glu_var_jopa_anal_low is failing. 