### PR TITLE
Modification of yaml to be compatible with new 'observed variables' yaml option

### DIFF
--- a/test/testinput/varobswriter_globalnamelist_sonde.yaml
+++ b/test/testinput/varobswriter_globalnamelist_sonde.yaml
@@ -11,6 +11,7 @@ observations:
       obsdatain:
         obsfile: Data/varobs_globalnamelist_sonde.nc4
       simulated variables: [theta, eastward_wind, northward_wind, relative_humidity]
+      observed variables: [theta, eastward_wind, northward_wind, relative_humidity]
     obs filters:
     # Set the flag of observations with missing values to "pass": we want to check if these
     # values are encoded correctly in the VarObsFile.
@@ -62,6 +63,7 @@ observations:
       obsdatain:
         obsfile: Data/varobs_globalnamelist_sonde.nc4
       simulated variables: [theta, eastward_wind, northward_wind, relative_humidity]
+      observed variables: [theta, eastward_wind, northward_wind, relative_humidity]
     obs filters:
     # Set the flag of observations with missing values to "pass": we want to check if these
     # values are encoded correctly in the VarObsFile.


### PR DESCRIPTION
## Description
It is now possible to list observed as well as simulated variables in the yaml. Whilst this functionality is backwards compatible for most yamls, the  varobswriter_globalnamelist_sonde.yaml requires the addition of the list for the ctest to perform as expected. 

Note that the without the change the ctest fails as by default the 'observed variables' list reads in all ObsValue variables in the file, and in this case that results in an extra variable in the observed variables list. The reference data in 
'expected_main_table_columns'  have not been specified with this additional variable in mind. It would also be possible to change the expected data to account for the additional variable instead of adding the 'observed variables' list in the yaml. 

## Acceptance Criteria (Definition of Done)

All ctests pass.

## Impact

This change should be compatible immediately. Once the below PRs are merged the opsinputs_varobswriter_globalnamelist_sonde will fail until this PR is merged. 

- [ ] JCSDA-internal/oops/pull/1736
- [ ]  JCSDA-internal/ioda/pull/711
- [ ] JCSDA-internal/ufo/pull/2031