### PR TITLE
FY3 update of NumLevelLevs 

### DIFF
--- a/deps/ops/code/OpsMod_Varobs/Ops_SetupVarobsLevDepC.inc
+++ b/deps/ops/code/OpsMod_Varobs/Ops_SetupVarobsLevDepC.inc
@@ -294,17 +294,17 @@ SELECT CASE (Observations % header % ObsGroup)
   CASE (ObsGroupMWSFY3B)
 
     ObsLevelType = 0.0
-    NumLevelLevs = NumObLev
+    NumLevelLevs = 1
 
   CASE (ObsGroupMWSFY3)
 
     ObsLevelType = 0.0
-    NumLevelLevs = NumObLev
+    NumLevelLevs = 1
 
   CASE (ObsGroupMWRI)
 
     ObsLevelType = 0.0
-    NumLevelLevs = NumObLev
+    NumLevelLevs = 1
 
   CASE (ObsGroupHLOSWIND)
   


### PR DESCRIPTION
## Description

NumLevelLevs need to be set to 1 for MWSFY3B, MWSFY3, and MWRI, as it is for other similar instruments.

### Issue(s) addressed

None

## Acceptance Criteria (Definition of Done)

Ctests passing and review accepted 
 
## Dependencies

None

## Impact

None