### PR TITLE
add MWRI to CMake

### DIFF
--- a/etc/CMakeLists.txt
+++ b/etc/CMakeLists.txt
@@ -14,6 +14,7 @@ list( APPEND opsinputs_etc
   global/cx/GMIlow.nl
   global/cx/GPSRO.nl
   global/cx/IASI.nl
+  global/cx/MWRI.nl
   global/cx/SatTCWV.nl
   global/cx/Sonde.nl
   global/cx/SSMIS.nl


### PR DESCRIPTION
MWRI CX file wasn't linking when using the nightly build, I realised this is because it wasn't in the CMakeList. Now updated  