### PR TITLE
Fix out-of-bounds bug

### DIFF
--- a/src/opsinputs/opsinputs_fill_mod.F90
+++ b/src/opsinputs/opsinputs_fill_mod.F90
@@ -481,8 +481,11 @@ if (obsspace_has(ObsSpace, JediGroupName, JediVarName)) then
       end if
       call opsinputs_fill_setpgefinal(PGE(iJediObs), MissingDouble, DoPackPGEs, El2(iObs, iLevel))
     end do
-    El2(iObs, numLevels + 1 : JediToOpsLayoutMapping % MaxNumLevelsPerObs) % Flags = &
-      ibset(0, FinalRejectFlag)
+    ! Reject any superfluous model levels
+    if (size(El2, 2) > numLevels) then
+       El2(iObs, numLevels + 1 : JediToOpsLayoutMapping % MaxNumLevelsPerObs) % Flags = &
+              ibset(0, FinalRejectFlag)
+    end if
   end do
 end if ! Data not present? OPS will produce a warning -- we don't need to duplicate it.
 end subroutine opsinputs_fill_fillelementtype2dfromsimulatedvariable_records


### PR DESCRIPTION
In the routine `opsinputs_fill_fillelementtype2dfromsimulatedvariable_records`, there is a short piece of code that sets flags for any unused levels in a record to failed:

```
    El2(iObs, numLevels + 1 : JediToOpsLayoutMapping % MaxNumLevelsPerObs) % Flags = &
      ibset(0, FinalRejectFlag)
```

However, in certain circumstances (e.g. a prescribed number of model levels, which occurs for averaged sonde data), this can lead to an out-of-bounds error if `numLevels + 1` is greater than the length of the second dimension of `El2`. In most cases nothing obvious happens (although memory corruption could occur behind the scenes), but occasionally there is a segfault.

To fix this the code has been modified to compare `numLevels` against `size(El2, 2)` and only fill in the flags if there are actually superfluous levels in `El2`.

Fixes #124 