### PR TITLE
GHA checkout jedi-cmake with submodules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,7 @@ jobs:
         with:
           path: ci/jedicmake
           repository: JCSDA-internal/jedi-cmake
+          submodules: true
           token: ${{ secrets.GH_PAT }}
       - name: checkout ioda
         uses: actions/checkout@v2


### PR DESCRIPTION
Due to JCSDA-internal/jedi-cmake#27.