### PR TITLE
Use jedi-cmake.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,9 @@ set( OPSINPUTS_LINKER_LANGUAGE CXX )
 # Dependencies
 ################################################################################
 
+## Dependencies
+find_package( jedicmake QUIET )  # Prefer find modules from jedi-cmake
+
 # Boost
 include_directories( ${Boost_INCLUDE_DIR} )
 


### PR DESCRIPTION
I have added a find_package for jedi-cmake.  The reason for this is to use the jedi-cmake version of FindNetCDF instead of the ecbuild version.  This is beneficial for situations where NetCDF C and NetCDF Fortran are installed in separate locations; the ecbuild version doesn't handle this very well and the jedi-cmake version is better.  It makes no difference for situations where NetCDF C, Fortran and C++ are installed in the same location, such as for bb.