### PR TITLE
Don't write creation times to varobs and cx headers

### DIFF
--- a/src/opsinputs/opsinputs_cxwriter_mod.F90
+++ b/src/opsinputs/opsinputs_cxwriter_mod.F90
@@ -99,9 +99,6 @@ use OpsMod_CXInfo, only: &
 use opsinputs_cxgenerate_mod, only: &
     MaxModelCodes,                  &
     Ops_ReadCXControlNL
-use OpsMod_DateTime, only: &
-    DateTime_type,         &
-    OpsFn_DateTime_now
 use OpsMod_Kinds, only: &
     integer64,          &
     logical64,          &
@@ -1370,7 +1367,6 @@ type(UM_header_type), intent(inout)  :: UmHeader
 ! Local declarations:
 integer                              :: NumLevels
 integer(c_int)                       :: year, month, day, hour, minute, second
-TYPE (DateTime_type)                 :: now
 
 ! Body:
 
@@ -1416,15 +1412,6 @@ UmHeader % FixHd(FH_VTHour) = hour
 UmHeader % FixHd(FH_VTMinute) = minute
 UmHeader % FixHd(FH_VTSecond) = second
 UmHeader % FixHd(FH_VTDayNo) = IMDI
-
-now = OpsFn_DateTime_now()
-UmHeader % FixHd(FH_CTYear) = now % year
-UmHeader % FixHd(FH_CTMonth) = now % month
-UmHeader % FixHd(FH_CTDay) = now % day
-UmHeader % FixHd(FH_CTHour) = now % hour
-UmHeader % FixHd(FH_CTMinute) = now % minute
-UmHeader % FixHd(FH_CTSecond) = now % second
-UmHeader % FixHd(FH_CTDayNo) = IMDI
 
 UmHeader % IntC = IMDI
 UmHeader % IntC(IC_XLen) = self % IC_XLen

--- a/src/opsinputs/opsinputs_varobswriter_mod.F90
+++ b/src/opsinputs/opsinputs_varobswriter_mod.F90
@@ -98,9 +98,6 @@ use OpsMod_Control, only:   &
     DefaultDocURL,          &
     mpi_group,              &
     Ops_InitMPI
-use OpsMod_DateTime, only: &
-    DateTime_type,         &
-    OpsFn_DateTime_now
 use OpsMod_MiscTypes, only: ElementHeader_Type
 use OpsMod_ObsGroupInfo, only: &
     OpsFn_ObsGroupNameToNum,   &
@@ -1454,7 +1451,6 @@ type(UM_header_type), intent(inout)     :: CxHeader
 
 ! Local declarations:
 integer(c_int)                          :: year, month, day, hour, minute, second
-TYPE (DateTime_type)                    :: now
 
 ! Body:
 
@@ -1487,15 +1483,6 @@ CxHeader % FixHd(FH_VTHour) = hour
 CxHeader % FixHd(FH_VTMinute) = minute
 CxHeader % FixHd(FH_VTSecond) = second
 CxHeader % FixHd(FH_VTDayNo) = 0  ! TODO(wsmigaj): What should this be set to?
-
-now = OpsFn_DateTime_now()
-CxHeader % FixHd(FH_CTYear) = now % year
-CxHeader % FixHd(FH_CTMonth) = now % month
-CxHeader % FixHd(FH_CTDay) = now % day
-CxHeader % FixHd(FH_CTHour) = now % hour
-CxHeader % FixHd(FH_CTMinute) = now % minute
-CxHeader % FixHd(FH_CTSecond) = now % second
-CxHeader % FixHd(FH_CTDayNo) = 0  ! TODO(wsmigaj): What should this be set to?
 
 CxHeader % IntC(IC_ShipWind) = self % IC_ShipWind
 CxHeader % IntC(IC_GroundGPSOperator) = self % IC_GroundGPSOperator


### PR DESCRIPTION
Code that sets the fixed length header values for creation time has been removed.

Tested in sith with a bb build that uses this branch:

- [bb build output](http://fcm1/cylc-review/cycles?user=frjm&suite=bb-opsinputs)
- [sith output](http://fcm1/cylc-review/cycles?user=frjm&suite=sith-opsinputs)

Inspection of the varobs and cx headers shows that the creation time header values are all IMDI (-32768) for cx files and 0 for varobs files. I don't think that inconsistency matters, it's a consequence of the way the fixed length header arrays are initialised.
