### PR TITLE
ensure GMIhigh has the correct ObsType

### DIFF
--- a/src/opsinputs/opsinputs_varobswriter_mod.F90
+++ b/src/opsinputs/opsinputs_varobswriter_mod.F90
@@ -743,6 +743,9 @@ if (self % FillObsTypeFromOpsSubType) then
 else
    call Ops_Alloc(Ob % Header % ObsType, "ObsType", Ob % Header % NumObsLocal, Ob % ObsType)
    Ob % ObsType(:) = Ops_SubTypeNameToNum(trim(self % ObsGroupName))
+   ! this is to make sure GMIhigh has the correct ObsType in its VarObs file
+   ! instead of that for GMIlow
+   if (Ob % header % ObsGroup == ObsGroupGMIhigh) Ob % ObsType(:) = ObsTypeGMIhigh
 end if
 
 if (obsspace_has(ObsSpace, "MetaData", "stationIdentification")) then


### PR DESCRIPTION
This modifies the VarObs Writer filter to make sure GMIhigh has the correct ObsType. This is necessary for VAR as in standard JOPA the ops_obstype for GMIlow and GMIhigh are the same 