### PR TITLE
Feature/remove c++11 req

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,8 +30,6 @@ ecbuild_requires_macro_version( 2.7 )
 ecbuild_declare_project()
 
 ecbuild_enable_fortran( REQUIRED )
-# set(CMAKE_CXX_STANDARD 11)
-# set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 set( OPSINPUTS_LINKER_LANGUAGE CXX )
 


### PR DESCRIPTION
This PR removes the hard dependency on c++11 standard.  When used in a bundle in conjunction with atlas which requires C++17 features enabled, developers are encouraged to enable C++17 standard at the top-level.

### Issues addressed
- [x] MetOffice/mo-bundle/issues/124