### PR TITLE
Add IC_BLevels parameter to CX and Varobs writers

### DIFF
--- a/src/opsinputs/CxWriterParameters.h
+++ b/src/opsinputs/CxWriterParameters.h
@@ -101,7 +101,7 @@ class CxWriterParameters : public oops::ObsFilterParametersBase {
   oops::Parameter<int> IC_YLen{"IC_YLen", 0, this};
   /// Number of levels (PLEVELS).
   oops::Parameter<int> IC_PLevels{"IC_PLevels", 0, this};
-  /// Number of levels (BLEVELS).
+  /// Number of boundary layer levels (BLEVELS).
   oops::Parameter<int> IC_BLevels{"IC_BLevels", 0, this};
   /// Number of wet levels (QLEVELS).
   oops::Parameter<int> IC_WetLevels{"IC_WetLevels", 0, this};

--- a/src/opsinputs/CxWriterParameters.h
+++ b/src/opsinputs/CxWriterParameters.h
@@ -101,6 +101,8 @@ class CxWriterParameters : public oops::ObsFilterParametersBase {
   oops::Parameter<int> IC_YLen{"IC_YLen", 0, this};
   /// Number of levels (PLEVELS).
   oops::Parameter<int> IC_PLevels{"IC_PLevels", 0, this};
+  /// Number of levels (BLEVELS).
+  oops::Parameter<int> IC_BLevels{"IC_BLevels", 0, this};
   /// Number of wet levels (QLEVELS).
   oops::Parameter<int> IC_WetLevels{"IC_WetLevels", 0, this};
   /// First rho level at which height is constant.

--- a/src/opsinputs/VarObsWriterParameters.h
+++ b/src/opsinputs/VarObsWriterParameters.h
@@ -137,7 +137,7 @@ class VarObsWriterParameters : public oops::ObsFilterParametersBase {
   oops::Parameter<int> IC_YLen{"IC_YLen", 0, this};
   /// Number of levels (PLEVELS).
   oops::Parameter<int> IC_PLevels{"IC_PLevels", 0, this};
-  /// Number of levels (BLEVELS).
+  /// Number of boundary layer levels (BLEVELS).
   oops::Parameter<int> IC_BLevels{"IC_BLevels", 0, this};
   /// Number of wet levels (QLEVELS).
   oops::Parameter<int> IC_WetLevels{"IC_WetLevels", 0, this};

--- a/src/opsinputs/VarObsWriterParameters.h
+++ b/src/opsinputs/VarObsWriterParameters.h
@@ -137,6 +137,8 @@ class VarObsWriterParameters : public oops::ObsFilterParametersBase {
   oops::Parameter<int> IC_YLen{"IC_YLen", 0, this};
   /// Number of levels (PLEVELS).
   oops::Parameter<int> IC_PLevels{"IC_PLevels", 0, this};
+  /// Number of levels (BLEVELS).
+  oops::Parameter<int> IC_BLevels{"IC_BLevels", 0, this};
   /// Number of wet levels (QLEVELS).
   oops::Parameter<int> IC_WetLevels{"IC_WetLevels", 0, this};
   /// True if ship winds have been adjusted to 10m.

--- a/src/opsinputs/opsinputs_cxwriter_mod.F90
+++ b/src/opsinputs/opsinputs_cxwriter_mod.F90
@@ -151,6 +151,7 @@ private
   integer(integer64)                     :: IC_XLen
   integer(integer64)                     :: IC_YLen
   integer(integer64)                     :: IC_PLevels
+  integer(integer64)                     :: IC_BLevels
   integer(integer64)                     :: IC_WetLevels
   integer(integer64)                     :: IC_FirstConstantRhoLevel
 
@@ -362,6 +363,9 @@ self % IC_YLen = IntValue
 
 call f_conf % get_or_die("IC_PLevels", IntValue)
 self % IC_PLevels = IntValue
+
+call f_conf % get_or_die("IC_BLevels", IntValue)
+self % IC_BLevels = IntValue
 
 call f_conf % get_or_die("IC_WetLevels", IntValue)
 self % IC_WetLevels = IntValue
@@ -1416,6 +1420,7 @@ UmHeader % IntC = IMDI
 UmHeader % IntC(IC_XLen) = self % IC_XLen
 UmHeader % IntC(IC_YLen) = self % IC_Ylen
 UmHeader % IntC(IC_PLevels) = self % IC_PLevels
+UmHeader % IntC(IC_BLevels) = self % IC_BLevels
 UmHeader % IntC(IC_WetLevels) = self % IC_WetLevels
 UmHeader % IntC(IC_FirstConstantRhoLevel) = self % IC_FirstConstantRhoLevel
 

--- a/src/opsinputs/opsinputs_varobswriter_mod.F90
+++ b/src/opsinputs/opsinputs_varobswriter_mod.F90
@@ -173,6 +173,7 @@ private
   integer(integer64) :: IC_XLen
   integer(integer64) :: IC_YLen
   integer(integer64) :: IC_PLevels
+  integer(integer64) :: IC_BLevels
   integer(integer64) :: IC_WetLevels
 
   real(real64)       :: RC_LongSpacing
@@ -461,6 +462,9 @@ self % IC_YLen = IntValue
 
 call f_conf % get_or_die("IC_PLevels", IntValue)
 self % IC_PLevels = IntValue
+
+call f_conf % get_or_die("IC_BLevels", IntValue)
+self % IC_BLevels = IntValue
 
 call f_conf % get_or_die("IC_WetLevels", IntValue)
 self % IC_WetLevels = IntValue
@@ -1531,6 +1535,7 @@ CxHeader % IntC(IC_GPSRO_Operator_press) = self % IC_GPSRO_Operator_press
 CxHeader % IntC(IC_XLen) = self % IC_XLen
 CxHeader % IntC(IC_YLen) = self % IC_Ylen
 CxHeader % IntC(IC_PLevels) = self % IC_PLevels
+CxHeader % IntC(IC_BLevels) = self % IC_BLevels
 CxHeader % IntC(IC_WetLevels) = self % IC_WetLevels
 
 CxHeader % RealC(RC_LongSpacing) = self % RC_LongSpacing


### PR DESCRIPTION
Add the `IC_BLevels` parameter, which specifies the number of model boundary layer levels.

This is necessary for SHPSYN data, for which the wind speed is interpolated to 20m height in VAR. `IC_BLevels` must be present in the CX header for the interpolation to work correctly.

Add the same parameter to the VarObs writer for symmetry and to avoid unintended consequences.