### PR TITLE
Add a smal change to bugfix map chans for seviri to work correctly.

### DIFF
--- a/src/opsinputs/opsinputs_fill_mod.F90
+++ b/src/opsinputs/opsinputs_fill_mod.F90
@@ -1116,6 +1116,8 @@ if (obsspace_has(ObsSpace, JediVarGroup, JediVarNamesWithChannels(1))) then
           else
             arrayindex = varChannels(iChannel)
           end if
+	else
+	  exit
         end if
       else 
         if (.not. compressChannels) then


### PR DESCRIPTION
When final testing was carried out on Seviri the VAR statistics did not look correct. This problem was only happening for channel 6. 

The bug comes about from seviri having 6 channels read in but only 5 output to the varobs. This meant that a loop which cycled on the number of channels went round 6 times. A variable called arrayindex was used to assign where in an array to palce a value, this is initially set as the loop number. For seviri the logic follows a route where the arrayindex was updated to be the actual channel number, however on the final loop 6 the if logic prevents the arrayindex being reallocated and so channel 6 gets filled with the final channel 11 observations. 

This is fixed by setting an exit on the loop if the condition is not met. 