### PR TITLE
Update yaml files with the new syntax for where variable is_defined / is_not_defined

### DIFF
--- a/test/testinput/003_VarField_rh_Sonde.yaml
+++ b/test/testinput/003_VarField_rh_Sonde.yaml
@@ -21,7 +21,7 @@ observations:
       where:
       - variable:
           name: ObsErrorData/relativeHumidity
-        is_defined:
+        value: is_valid
       action:
         name: inflate error
         inflation factor: 2.0

--- a/test/testinput/004_VarField_u_Sonde.yaml
+++ b/test/testinput/004_VarField_u_Sonde.yaml
@@ -21,7 +21,7 @@ observations:
       where:
       - variable:
           name: ObsErrorData/windEastward
-        is_defined:
+        value: is_valid
       action:
         name: inflate error
         inflation factor: 2.0

--- a/test/testinput/005_VarField_v_Sonde.yaml
+++ b/test/testinput/005_VarField_v_Sonde.yaml
@@ -21,7 +21,7 @@ observations:
       where:
       - variable:
           name: ObsErrorData/windNorthward
-        is_defined:
+        value: is_valid
       action:
         name: inflate error
         inflation factor: 2.0

--- a/test/testinput/078_VarField_theta.yaml
+++ b/test/testinput/078_VarField_theta.yaml
@@ -21,7 +21,7 @@ observations:
       where:
       - variable:
           name: ObsErrorData/potentialTemperature
-        is_defined:
+        value: is_valid
       action:
         name: inflate error
         inflation factor: 2.0

--- a/test/testinput/081_VarField_level_time.yaml
+++ b/test/testinput/081_VarField_level_time.yaml
@@ -21,7 +21,7 @@ observations:
       where:
       - variable:
           name: ObsErrorData/potentialTemperature
-        is_defined:
+        value: is_valid
       action:
         name: inflate error
         inflation factor: 2.0

--- a/test/testinput/082_VarField_level_lat.yaml
+++ b/test/testinput/082_VarField_level_lat.yaml
@@ -21,7 +21,7 @@ observations:
       where:
       - variable:
           name: ObsErrorData/potentialTemperature
-        is_defined:
+        value: is_valid
       action:
         name: inflate error
         inflation factor: 2.0

--- a/test/testinput/083_VarField_level_lon.yaml
+++ b/test/testinput/083_VarField_level_lon.yaml
@@ -21,7 +21,7 @@ observations:
       where:
       - variable:
           name: ObsErrorData/potentialTemperature
-        is_defined:
+        value: is_valid
       action:
         name: inflate error
         inflation factor: 2.0

--- a/test/testinput/cxwriter_globalnamelist_iasi.yaml
+++ b/test/testinput/cxwriter_globalnamelist_iasi.yaml
@@ -35,7 +35,7 @@ observations:
       where:
       - variable:
           name: MetaData/latitude #ensures ob2 is failed
-        is_not_defined:
+        value: is_not_valid
     - filter: Cx Writer
       variables_for_quality_control:
       - name: brightnessTemperature

--- a/test/testinput/varobswriter_globalnamelist_abiclr.yaml
+++ b/test/testinput/varobswriter_globalnamelist_abiclr.yaml
@@ -25,7 +25,7 @@ observations:
       where:
       - variable:
           name: MetaData/latitude
-        is_not_defined:
+        value: is_not_valid
     - filter: VarObs Writer
       namelist_directory: ../etc/global/varobs
       general_mode: debug
@@ -77,7 +77,7 @@ observations:
       where:
       - variable:
           name: MetaData/latitude
-        is_not_defined:
+        value: is_not_valid
     - filter: VarObs Writer
       namelist_directory: ../etc/global/varobs
       general_mode: debug

--- a/test/testinput/varobswriter_globalnamelist_ahiclr.yaml
+++ b/test/testinput/varobswriter_globalnamelist_ahiclr.yaml
@@ -25,7 +25,7 @@ observations:
       where:
       - variable:
           name: MetaData/latitude
-        is_not_defined:
+        value: is_not_valid
     - filter: VarObs Writer
       namelist_directory: ../etc/global/varobs
       general_mode: debug
@@ -77,7 +77,7 @@ observations:
       where:
       - variable:
           name: MetaData/latitude
-        is_not_defined:
+        value: is_not_valid
     - filter: VarObs Writer
       namelist_directory: ../etc/global/varobs
       general_mode: debug

--- a/test/testinput/varobswriter_globalnamelist_aircraft.yaml
+++ b/test/testinput/varobswriter_globalnamelist_aircraft.yaml
@@ -28,7 +28,7 @@ observations:
       where:
       - variable:
           name: MetaData/latitude
-        is_not_defined:
+        value: is_not_valid
       defer to post: true
     # Copy latitude, longitude and dateTime to 'initial' values which
     # are then used in the Varobs writer.
@@ -101,7 +101,7 @@ observations:
       where:
       - variable:
           name: MetaData/latitude
-        is_not_defined:
+        value: is_not_valid
       defer to post: true
     - filter: VarObs Writer
       namelist_directory: ../etc/global/varobs

--- a/test/testinput/varobswriter_globalnamelist_atms.yaml
+++ b/test/testinput/varobswriter_globalnamelist_atms.yaml
@@ -25,7 +25,7 @@ observations:
       where:
       - variable:
           name: MetaData/latitude
-        is_not_defined:
+        value: is_not_valid
     - filter: VarObs Writer
       namelist_directory: ../etc/global/varobs
       general_mode: debug
@@ -77,7 +77,7 @@ observations:
       where:
       - variable:
           name: MetaData/latitude
-        is_not_defined:
+        value: is_not_valid
     - filter: VarObs Writer
       namelist_directory: ../etc/global/varobs
       general_mode: debug

--- a/test/testinput/varobswriter_globalnamelist_atovs.yaml
+++ b/test/testinput/varobswriter_globalnamelist_atovs.yaml
@@ -22,7 +22,7 @@ observations:
       where:
       - variable:
           name: MetaData/latitude #ensures ob2 is failed
-        is_not_defined:
+        value: is_not_valid
     - filter: VarObs Writer
       namelist_directory: ../etc/global/varobs
       general_mode: verbose

--- a/test/testinput/varobswriter_globalnamelist_iasi.yaml
+++ b/test/testinput/varobswriter_globalnamelist_iasi.yaml
@@ -33,7 +33,7 @@ observations:
       where:
       - variable:
           name: MetaData/latitude #ensures ob2 is failed
-        is_not_defined:
+        value: is_not_valid
     - filter: VarObs Writer
       namelist_directory: ../etc/global/varobs
       variables_for_quality_control:

--- a/test/testinput/varobswriter_globalnamelist_scatwind.yaml
+++ b/test/testinput/varobswriter_globalnamelist_scatwind.yaml
@@ -91,7 +91,7 @@ observations:
       where:
       - variable:
           name: MetaData/latitude
-        is_not_defined:
+        value: is_not_valid
     - filter: VarObs Writer
       namelist_directory: ../etc/global/varobs
       general_mode: debug
@@ -162,7 +162,7 @@ observations:
       where:
       - variable:
           name: MetaData/latitude
-        is_not_defined:
+        value: is_not_valid
     - filter: VarObs Writer
       namelist_directory: ../etc/global/varobs
       general_mode: debug

--- a/test/testinput/varobswriter_globalnamelist_seviriclr.yaml
+++ b/test/testinput/varobswriter_globalnamelist_seviriclr.yaml
@@ -25,7 +25,7 @@ observations:
       where:
       - variable:
           name: MetaData/latitude
-        is_not_defined:
+        value: is_not_valid
     - filter: VarObs Writer
       namelist_directory: ../etc/global/varobs
       general_mode: debug
@@ -77,7 +77,7 @@ observations:
       where:
       - variable:
           name: MetaData/latitude
-        is_not_defined:
+        value: is_not_valid
     - filter: VarObs Writer
       namelist_directory: ../etc/global/varobs
       general_mode: debug

--- a/test/testinput/varobswriter_globalnamelist_sonde.yaml
+++ b/test/testinput/varobswriter_globalnamelist_sonde.yaml
@@ -28,7 +28,7 @@ observations:
       where:
       - variable:
           name: MetaData/latitude
-        is_not_defined:
+        value: is_not_valid
       defer to post: true
     # Copy latitude, longitude and dateTime to 'initial' values which
     # are then used in the Varobs writer.
@@ -101,7 +101,7 @@ observations:
       where:
       - variable:
           name: MetaData/latitude
-        is_not_defined:
+        value: is_not_valid
       defer to post: true
     - filter: VarObs Writer
       namelist_directory: ../etc/global/varobs

--- a/test/testinput/varobswriter_ukvnamelist_sonde.yaml
+++ b/test/testinput/varobswriter_ukvnamelist_sonde.yaml
@@ -24,7 +24,7 @@ observations:
       where:
       - variable:
           name: MetaData/latitude
-        is_not_defined:
+        value: is_not_valid
       defer to post: true
     - filter: VarObs Writer
       namelist_directory: ../etc/ukv/varobs

--- a/test/testinput/varobswriter_ukvnamelist_surfacecloud.yaml
+++ b/test/testinput/varobswriter_ukvnamelist_surfacecloud.yaml
@@ -26,7 +26,7 @@ observations:
       where:
       - variable:
           name: MetaData/latitude
-        is_not_defined:
+        value: is_not_valid
       defer to post: true
     - filter: VarObs Writer
       namelist_directory: ../etc/ukv/varobs


### PR DESCRIPTION
### Description
Refactors yamls in processWhere for is_defined and is_not_defined

### Issue(s) addressed
Resolves #193 

### Impact
Requires changes in yamls that use filters with where statement:
`is_defined:` -> changed to `value: is_valid`
`is_not_defined:` -> changed to `value: is_not_valid`