### PR TITLE
Fixes for NAG.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,9 @@ include_directories( ${IODA_INCLUDE_DIRS} )
 find_package( oops REQUIRED )
 include_directories( ${OOPS_INCLUDE_DIRS} )
 
+find_package(SHUM REQUIRED)
+include_directories( ${SHUM_INCLUDE_DIR} )
+
 ################################################################################
 # Export package info
 ################################################################################

--- a/deps/CMakeLists.txt
+++ b/deps/CMakeLists.txt
@@ -44,6 +44,15 @@ ${CMAKE_Fortran_FLAGS}"
 -check uninit \
 ${CMAKE_Fortran_DEBUG_FLAGS}"
   )
+elseif ("${CMAKE_Fortran_COMPILER_ID}" MATCHES "NAG")
+  set(OPS_DEFAULT_Fortran_FLAGS "\
+-double \
+${CMAKE_Fortran_FLAGS}"
+#-Wp,-P \
+  )
+  set(CMAKE_Fortran_DEBUG_FLAGS "\
+${CMAKE_Fortran_DEBUG_FLAGS}"
+  )
 endif()
 
 list( APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake )

--- a/deps/gcom/CMakeLists.txt
+++ b/deps/gcom/CMakeLists.txt
@@ -13,8 +13,7 @@ endif()
 
 set(CMAKE_Fortran_FLAGS "\
 ${OPS_DEFAULT_Fortran_FLAGS} \
-${GCOM_EXTRA_Fortran_FLAGS} \
-${CMAKE_Fortran_FLAGS}")
+${GCOM_EXTRA_Fortran_FLAGS}")
 
 set(GCOM_SOURCE_FILES
   gc/gc__abort.c
@@ -213,9 +212,16 @@ set(GCOM_SOURCE_DIRS
 
 # Setup the parallel version of the gcom library
 
-ecbuild_add_library(
-  TARGET gcom
-  SOURCES ${GCOM_SOURCE_FILES})
+if("${CMAKE_Fortran_COMPILER_ID}" MATCHES "NAG")
+  ecbuild_add_library(
+    TARGET gcom
+    SOURCES ${GCOM_SOURCE_FILES}
+    LINKER_LANGUAGE CXX)
+else()
+  ecbuild_add_library(
+    TARGET gcom
+    SOURCES ${GCOM_SOURCE_FILES})
+endif()
  
 target_compile_definitions(gcom PRIVATE 
   GC_VERSION="'7.2'" 
@@ -240,9 +246,16 @@ target_include_directories(gcom
 
 # Setup the serial version of the gcom library
 
-ecbuild_add_library(
-  TARGET gcom_serial
-  SOURCES ${GCOM_SOURCE_FILES})
+if("${CMAKE_Fortran_COMPILER_ID}" MATCHES "NAG")
+  ecbuild_add_library(
+    TARGET gcom_serial
+    SOURCES ${GCOM_SOURCE_FILES}
+    LINKER_LANGUAGE CXX)
+else()
+  ecbuild_add_library(
+    TARGET gcom_serial
+    SOURCES ${GCOM_SOURCE_FILES})
+endif()
 
 # For the serial version, skip the MPI_SRC symbol...
 target_compile_definitions(gcom_serial PRIVATE

--- a/deps/odb/CMakeLists.txt
+++ b/deps/odb/CMakeLists.txt
@@ -9,17 +9,23 @@ endif()
 
 set(CMAKE_Fortran_FLAGS "\
 ${OPS_DEFAULT_Fortran_FLAGS} \
-${ODB_EXTRA_Fortran_FLAGS} \
-${CMAKE_Fortran_FLAGS}")
+${ODB_EXTRA_Fortran_FLAGS}")
 
 set(ODB_SOURCE_FILES
   stubs/parkind1.F90
   stubs/yomhook.F90
 )
 
-ecbuild_add_library(
-  TARGET odb
-  SOURCES ${ODB_SOURCE_FILES})
+if("${CMAKE_Fortran_COMPILER_ID}" MATCHES "NAG")
+  ecbuild_add_library(
+    TARGET odb
+    SOURCES ${ODB_SOURCE_FILES}
+    LINKER_LANGUAGE CXX)
+else()
+  ecbuild_add_library(
+    TARGET odb
+    SOURCES ${ODB_SOURCE_FILES})
+endif()
 
 get_target_property(ODB_Fortran_MODULE_DIRECTORY odb Fortran_MODULE_DIRECTORY)
 

--- a/deps/ops/CMakeLists.txt
+++ b/deps/ops/CMakeLists.txt
@@ -13,8 +13,7 @@ endif()
 
 set(CMAKE_Fortran_FLAGS "\
 ${OPS_DEFAULT_Fortran_FLAGS} \
-${OPS_EXTRA_Fortran_FLAGS} \
-${CMAKE_Fortran_FLAGS}")
+${OPS_EXTRA_Fortran_FLAGS}")
 
 set(OPS_SOURCE_FILES
   code/GenMod_ModelIO/GenMod_ModelIO.F90
@@ -111,6 +110,7 @@ foreach (file ${OPS_SOURCE_FILES})
   list(APPEND OPS_SOURCE_DIRS "${dir}")
 endforeach()
 list(REMOVE_DUPLICATES OPS_SOURCE_DIRS)
+include_directories( ${OPS_SOURCE_DIRS} )
 
 # Find extra dependencies
 
@@ -119,8 +119,14 @@ find_package(SHUM REQUIRED)
 
 # Setup the parallel version of the ops library
 
-ecbuild_add_library(TARGET ops
-  SOURCES ${OPS_SOURCE_FILES})
+if("${CMAKE_Fortran_COMPILER_ID}" MATCHES "NAG")
+  ecbuild_add_library(TARGET ops
+    SOURCES ${OPS_SOURCE_FILES}
+    LINKER_LANGUAGE CXX)
+else()
+  ecbuild_add_library(TARGET ops
+    SOURCES ${OPS_SOURCE_FILES})
+endif()
 
 target_compile_definitions(ops PRIVATE 
   EXTERNAL_GCOM
@@ -163,8 +169,14 @@ target_include_directories(ops
 
 # Setup the serial version of the ops library, linked to gcom_serial
 
-ecbuild_add_library(TARGET ops_serial
-  SOURCES ${OPS_SOURCE_FILES})
+if("${CMAKE_Fortran_COMPILER_ID}" MATCHES "NAG")
+  ecbuild_add_library(TARGET ops_serial
+    SOURCES ${OPS_SOURCE_FILES}
+    LINKER_LANGUAGE CXX)
+else()
+  ecbuild_add_library(TARGET ops_serial
+    SOURCES ${OPS_SOURCE_FILES})
+endif()
 
 target_compile_definitions(ops_serial PRIVATE
   EXTERNAL_GCOM
@@ -212,16 +224,32 @@ target_include_directories(ops_serial
 
 set(CMAKE_EXECUTABLE_SUFFIX .exe)
 
-ecbuild_add_executable(TARGET OpsProg_PrintCXFile
-  SOURCES
-  code/OpsProg_Utils/OpsMod_PrintCX.f90
-  code/OpsProg_Utils/OpsProg_PrintCXFile.F90)
+if("${CMAKE_Fortran_COMPILER_ID}" MATCHES "NAG")
+  ecbuild_add_executable(TARGET OpsProg_PrintCXFile
+    SOURCES
+    code/OpsProg_Utils/OpsMod_PrintCX.f90
+    code/OpsProg_Utils/OpsProg_PrintCXFile.F90
+    LINKER_LANGUAGE CXX)
+else()
+  ecbuild_add_executable(TARGET OpsProg_PrintCXFile
+    SOURCES
+    code/OpsProg_Utils/OpsMod_PrintCX.f90
+    code/OpsProg_Utils/OpsProg_PrintCXFile.F90)
+endif()
 target_link_libraries(OpsProg_PrintCXFile
   PRIVATE ops_serial)
 
-ecbuild_add_executable(TARGET OpsProg_PrintVarobs
-  SOURCES
-  code/OpsProg_Utils/OpsMod_PrintVarobs.f90
-  code/OpsProg_Utils/OpsProg_PrintVarobs.F90)
+if("${CMAKE_Fortran_COMPILER_ID}" MATCHES "NAG")
+  ecbuild_add_executable(TARGET OpsProg_PrintVarobs
+    SOURCES
+    code/OpsProg_Utils/OpsMod_PrintVarobs.f90
+    code/OpsProg_Utils/OpsProg_PrintVarobs.F90
+    LINKER_LANGUAGE CXX)
+else()
+  ecbuild_add_executable(TARGET OpsProg_PrintVarobs
+    SOURCES
+    code/OpsProg_Utils/OpsMod_PrintVarobs.f90
+    code/OpsProg_Utils/OpsProg_PrintVarobs.F90)
+endif()
 target_link_libraries(OpsProg_PrintVarobs
   PRIVATE ops_serial)

--- a/src/opsinputs/CMakeLists.txt
+++ b/src/opsinputs/CMakeLists.txt
@@ -43,6 +43,8 @@ if("${CMAKE_Fortran_COMPILER_ID}" MATCHES "GNU")
   set(FORTRAN_FLAGS_64_BIT_TYPES "-fdefault-real-8 -fdefault-integer-8")
 elseif ("${CMAKE_Fortran_COMPILER_ID}" MATCHES "Intel")
   set(FORTRAN_FLAGS_64_BIT_TYPES "-integer-size 64 -real-size 64")
+elseif ("${CMAKE_Fortran_COMPILER_ID}" MATCHES "NAG")
+  set(FORTRAN_FLAGS_64_BIT_TYPES "-double")
 endif()
 set_source_files_properties(opsinputs_cxgenerate_mod.F90 PROPERTIES
                             COMPILE_FLAGS "${FORTRAN_FLAGS_64_BIT_TYPES}")


### PR DESCRIPTION
This is a mixture of changes, I couldn't easily separate them.  Addresses #197.  The changes are:

1) Detect shumlib at the top of the tree.  It is needed in different subdirectories.  The problem is that compilers behave differently with modules that are used transitively, i.e. procedure X uses module A which uses module B.  Without this change src/opsinputs/opsinputs_cxwriter_mod.F90 fails to compile because it cannot find a shumlib module.  This file doesn't reference shumlib but it does use modules that use shumlib.

2) There are various sections of the cmake files that set specific options for different compilers.  I have added sections for NAG.

3) There are places CMAKE_Fortran_FLAGS is appended in ways that result in options appearing multiple times on the same command line.  Some compilers tolerate this but nagfor does not.

4) Linking with nagfor results in problems due to the addition of linker flags that aren't compatible with nagfor's syntax.  Linking with C++ is simpler.  I have only done this for nagfor.

5) This include directories for the OPS directories were not actually being added, I have done that here (also for shumlib).  The reason this doesn't matter for the other compilers is that they implicitly search the directory that the source file is contained it.  nagfor doesn't however so the directories need to be added explicitly.