### PR TITLE
Remove literal kinds

### DIFF
--- a/src/opsinputs/opsinputs_fill_mod.F90
+++ b/src/opsinputs/opsinputs_fill_mod.F90
@@ -1782,9 +1782,9 @@ character(len=*), intent(in)                       :: JediVarName
 character(len=*), intent(in)                       :: JediVarGroup
 
 ! Local declarations:
-integer(kind=4)                                    :: VarValue(JediToOpsLayoutMapping % NumJediObs)
-integer(kind=4)                                    :: CurrentVarValue
-integer(kind=4)                                    :: MissingInt
+integer(kind=c_int)                                :: VarValue(JediToOpsLayoutMapping % NumJediObs)
+integer(kind=c_int)                                :: CurrentVarValue
+integer(kind=c_int)                                :: MissingInt
 integer                                            :: i
 
 ! Body:
@@ -1864,7 +1864,7 @@ integer                                            :: i
 if (obsspace_has(ObsSpace, JediVarGroup, JediVarName)) then
   ! Retrieve data from JEDI
   call opsinputs_obsspace_get_db_string(ObsSpace, JediVarGroup, JediVarName, &
-                                        int(StringLen, kind=4), VarValue)
+                                        int(StringLen, kind=c_int), VarValue)
 
   ! Fill the OPS data structures
   call Ops_Alloc(Hdr, OpsVarName, JediToOpsLayoutMapping % NumOpsObs, String1)

--- a/src/opsinputs/opsinputs_varobswriter_mod.F90
+++ b/src/opsinputs/opsinputs_varobswriter_mod.F90
@@ -1479,14 +1479,14 @@ character(len=*), intent(in)                    :: JediVarName
 
 ! Local arguments:
 character(len=max_varname_with_channel_length) :: JediVarNamesWithChannels(max(size(Channels), 1))
-character(len=MAXVARLEN)        :: satidname
-real(kind=c_double)             :: VarValue(NumObs)
-real(kind=c_double)             :: MissingDouble
-integer(kind=4)                 :: SatIdValue(NumObs)
-integer(kind=4), allocatable    :: UniqueSatIds(:)
-integer                         :: ii, jj
-integer, parameter              :: maxpred = 31
-character(len=*), parameter     :: PredictorBaseName(1:maxpred) = (/ &
+character(len=MAXVARLEN)         :: satidname
+real(kind=c_double)              :: VarValue(NumObs)
+real(kind=c_double)              :: MissingDouble
+integer(kind=c_int)              :: SatIdValue(NumObs)
+integer(kind=c_int), allocatable :: UniqueSatIds(:)
+integer                          :: ii, jj
+integer, parameter               :: maxpred = 31
+character(len=*), parameter      :: PredictorBaseName(1:maxpred) = (/ &
               "constant                  ", &
               "thickness_850_300hPa      ", &
               "thickness_200_50hPa       ", &
@@ -1628,11 +1628,11 @@ end subroutine opsinputs_varobswriter_populatecxheader
 subroutine unique_values(input, output, positive)
 implicit none
 
-integer(kind=4), intent(in)               :: input(:)
-integer(kind=4), allocatable, intent(out) :: output(:)
-logical, optional, intent(in)             :: positive
+integer(kind=c_int), intent(in)               :: input(:)
+integer(kind=c_int), allocatable, intent(out) :: output(:)
+logical, optional, intent(in)                 :: positive
 
-integer(kind=4), allocatable :: unique(:)
+integer(kind=c_int), allocatable :: unique(:)
 integer :: i, j, k
 
 if (size(input) > 0) then


### PR DESCRIPTION
Resolves #138.  I don't think there are any other cases.  c_int seems most consistent with everything else.

Test output:

http://fcm1/cylc-review/taskjobs/frwd?&suite=opsinputs-138