### PR TITLE
AOCC support

### DIFF
--- a/deps/CMakeLists.txt
+++ b/deps/CMakeLists.txt
@@ -37,6 +37,12 @@ elseif ("${CMAKE_Fortran_COMPILER_ID}" MATCHES "Intel")
 ${CMAKE_Fortran_FLAGS}"
 #-Wp,-P \
   )
+elseif ("${CMAKE_Fortran_COMPILER_ID}" MATCHES "Flang")
+  set(OPS_DEFAULT_Fortran_FLAGS "\
+-fdefault-integer-8 -fdefault-real-8 \
+${CMAKE_Fortran_FLAGS}"
+#-Wp,-P \
+  )
   set(CMAKE_Fortran_DEBUG_FLAGS "\
 -check bounds \
 -check format \

--- a/src/opsinputs/CMakeLists.txt
+++ b/src/opsinputs/CMakeLists.txt
@@ -45,6 +45,8 @@ elseif ("${CMAKE_Fortran_COMPILER_ID}" MATCHES "Intel")
   set(FORTRAN_FLAGS_64_BIT_TYPES "-integer-size 64 -real-size 64")
 elseif ("${CMAKE_Fortran_COMPILER_ID}" MATCHES "NAG")
   set(FORTRAN_FLAGS_64_BIT_TYPES "-double")
+elseif ("${CMAKE_Fortran_COMPILER_ID}" MATCHES "Flang")
+  set(FORTRAN_FLAGS_64_BIT_TYPES "-fdefault-integer-8 -fdefault-real-8")
 endif()
 set_source_files_properties(opsinputs_cxgenerate_mod.F90 PROPERTIES
                             COMPILE_FLAGS "${FORTRAN_FLAGS_64_BIT_TYPES}")


### PR DESCRIPTION
This is some minimal changes for AOCC porting on EXZ.  Test output:

http://fcm1/cylc-review/taskjobs/frwd?&suite=opsinputs-201