### PR TITLE
Changes required for addition of `oops::Variable`. Targeted merge: 11/06/24

### DIFF
--- a/src/opsinputs/opsinputs_obsdatavector_mod.F90
+++ b/src/opsinputs/opsinputs_obsdatavector_mod.F90
@@ -6,7 +6,7 @@
 
 module opsinputs_obsdatavector_mod
 
-use oops_variables_mod, only: oops_variables
+use obs_variables_mod, only: obs_variables
 use string_f_c_mod, only: f_c_string
 use, intrinsic :: iso_c_binding, only: c_char, c_int, c_float, c_ptr, c_size_t
 
@@ -38,13 +38,13 @@ end function opsinputs_obsdatavector_int_nlocs
 
 !> Return an object wrapping the list of names of variables held in this ObsDataVector<int> object.
 
-type(oops_variables) function opsinputs_obsdatavector_int_varnames(c_vec)
+type(obs_variables) function opsinputs_obsdatavector_int_varnames(c_vec)
   !use, intrinsic :: iso_c_binding, only: c_ptr
-  !use oops_variables_mod
+  !use obs_variables_mod
   implicit none
   type(c_ptr), value, intent(in) :: c_vec
 
-  opsinputs_obsdatavector_int_varnames = oops_variables(c_opsinputs_obsdatavector_int_varnames(c_vec))
+  opsinputs_obsdatavector_int_varnames = obs_variables(c_opsinputs_obsdatavector_int_varnames(c_vec))
 end function opsinputs_obsdatavector_int_varnames
 
 !> Return true if this ObsDataVector<int> object contains a given variable.
@@ -93,14 +93,14 @@ end function opsinputs_obsdatavector_float_nlocs
 
 !> Return an object wrapping the list of names of variables held in this ObsDataVector<int> object.
 
-type(oops_variables) function opsinputs_obsdatavector_float_varnames(c_vec)
+type(obs_variables) function opsinputs_obsdatavector_float_varnames(c_vec)
   !use, intrinsic :: iso_c_binding
-  use oops_variables_mod
+  use obs_variables_mod
   implicit none
   type(c_ptr), value, intent(in) :: c_vec
 
   opsinputs_obsdatavector_float_varnames = &
-    oops_variables(c_opsinputs_obsdatavector_float_varnames(c_vec))
+    obs_variables(c_opsinputs_obsdatavector_float_varnames(c_vec))
 end function opsinputs_obsdatavector_float_varnames
 
 !> Return true if this ObsDataVector<float> object contains a given variable.

--- a/src/opsinputs/opsinputs_utils_mod.F90
+++ b/src/opsinputs/opsinputs_utils_mod.F90
@@ -6,7 +6,7 @@
 module opsinputs_utils_mod
 
 use, intrinsic :: iso_c_binding, only: c_int32_t
-use oops_variables_mod, only: oops_variables
+use obs_variables_mod, only: obs_variables
 use ufo_vars_mod, only: MAXVARLEN
 use opsinputs_obsdatavector_mod, only:    &
     opsinputs_obsdatavector_int_varnames, &
@@ -62,7 +62,7 @@ logical, intent(in)                                :: RejectObsWithAllVariablesF
 integer(kind=integer64), intent(out)               :: ReportFlags(:)
 
 ! Local declarations:
-type(oops_variables)                               :: ObsVariables
+type(obs_variables)                                :: ObsVariables
 character(max_varname_length)                      :: VarName
 integer                                            :: NumObsVariables
 integer                                            :: iVar, iOpsObs, iJediObsInRecord, iJediObs

--- a/src/opsinputs/opsinputs_varobswriter_mod.F90
+++ b/src/opsinputs/opsinputs_varobswriter_mod.F90
@@ -1365,7 +1365,7 @@ integer(integer64), intent(out) :: ChannelCounts(NumObs)
 
 ! Local declarations:
 integer                         :: NumChannels
-type(oops_variables)            :: Variables
+type(obs_variables)             :: Variables
 character(max_varname_length)   :: VariableName
 integer                         :: NumVariables, NumMultichannelVariables
 integer                         :: iMultichannelVariable, iChannel, iVariable, iObs


### PR DESCRIPTION
## Description.

For https://github.com/JCSDA-internal/oops/pull/2646.
Fixes a segfault with the latest OOPS update. Changes oops_variables -> obs_variables such as is seen in the IODA change: https://github.com/JCSDA-internal/ioda/pull/1283/files.

Requires testing with all other `feature/use_variable` branches.

## Issue

Resolves #209 

## Dependencies

Targeted merge date: 11/06/24.
- [ ] https://github.com/JCSDA-internal/oops/pull/2646

## Impact

Fixes usage of opsinputs downstream, with ops-um-jedi and lfric-lite-jedi atms_hofx tests.