### PR TITLE
General Mode in post filters now as per yaml

### DIFF
--- a/src/opsinputs/opsinputs_cxwriter_mod.F90
+++ b/src/opsinputs/opsinputs_cxwriter_mod.F90
@@ -157,6 +157,7 @@ private
   integer(integer64)                     :: IC_BLevels
   integer(integer64)                     :: IC_WetLevels
   integer(integer64)                     :: IC_FirstConstantRhoLevel
+  integer                                :: GeneralMode ! Local scope to ensure it propogates correctly
 
   real(real64)                           :: RC_LongSpacing
   real(real64)                           :: RC_LatSpacing
@@ -230,6 +231,7 @@ case default
   opsinputs_cxwriter_create = .false.
   return
 end select
+self % GeneralMode = GeneralMode
 
 call Gen_SetupControl(DefaultDocURL)
 call Ops_InitMPI
@@ -510,10 +512,12 @@ logical                                :: ConvertRecordsToMultilevelObs
 type(opsinputs_jeditoopslayoutmapping) :: JediToOpsLayoutMapping
 
 ! Body:
-
+GeneralMode = self % GeneralMode
 self % GeoVals => GeoVals
 self % varnames = varnames
 self % hofx => hofx
+
+write(*,*) "GeneralMode in opsinputs_cxwriter_post = ", GeneralMode
 
 ! For sondes, each profile is stored in a separate record of the JEDI ObsSpace, but
 ! it should be treated as a single (multi-level) ob in the OPS data structures.

--- a/src/opsinputs/opsinputs_cxwriter_mod.F90
+++ b/src/opsinputs/opsinputs_cxwriter_mod.F90
@@ -517,8 +517,6 @@ self % GeoVals => GeoVals
 self % varnames = varnames
 self % hofx => hofx
 
-write(*,*) "GeneralMode in opsinputs_cxwriter_post = ", GeneralMode
-
 ! For sondes, each profile is stored in a separate record of the JEDI ObsSpace, but
 ! it should be treated as a single (multi-level) ob in the OPS data structures.
 ! There may be other obs groups requiring similar treatment -- if so, edit the line below.

--- a/src/opsinputs/opsinputs_varobswriter_mod.F90
+++ b/src/opsinputs/opsinputs_varobswriter_mod.F90
@@ -570,8 +570,6 @@ integer(integer64)                          :: NumVarObsTotal
 GeneralMode = self % GeneralMode
 self % ObsDiags => obsdiags
 
-write(*,*) "GeneralMode in opsinputs_varobswriter_post = ", GeneralMode
-
 ! For sondes, each profile is stored in a separate record of the JEDI ObsSpace, but
 ! it should be treated as a single (multi-level) ob in the OPS data structures.
 ! There may be other obs groups requiring similar treatment -- if so, edit the line below.

--- a/src/opsinputs/opsinputs_varobswriter_mod.F90
+++ b/src/opsinputs/opsinputs_varobswriter_mod.F90
@@ -194,6 +194,7 @@ private
   integer(c_int), allocatable :: varChannels(:)
   integer(integer64) :: size_of_varobs_array
   integer(integer64) :: NumVarChannels
+  integer            :: GeneralMode ! Local scope to ensure it propogates correctly
 
   logical :: compressVarChannels
   logical :: increaseChanArray
@@ -272,6 +273,7 @@ case default
   opsinputs_varobswriter_create = .false.
   return
 end select
+self % GeneralMode = GeneralMode
 
 if (comm_is_valid .and. comm /= mpl_comm_world) then
   call gc_init_final(mype, nproc, comm)
@@ -565,7 +567,10 @@ type(UM_header_type)                        :: CxHeader
 integer(integer64)                          :: NumVarObsTotal
 
 ! Body:
+GeneralMode = self % GeneralMode
 self % ObsDiags => obsdiags
+
+write(*,*) "GeneralMode in opsinputs_varobswriter_post = ", GeneralMode
 
 ! For sondes, each profile is stored in a separate record of the JEDI ObsSpace, but
 ! it should be treated as a single (multi-level) ob in the OPS data structures.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -315,11 +315,6 @@ ADD_WRITER_TEST(NAME     varobswriter_nested_output_directory
                 DATA     028_VarField_satid.nc4
                 DONT_SET_OPS_OUTPUT_DIR_ENV_VAR)
 
-# Tests on combined varobs and cx writer for global namelist
-ADD_WRITER_TEST(NAME     bothwriters_globalnamelist_atms
-                YAML     bothwriters_globalnamelist_atms.yaml
-                DATA     varobs_globalnamelist_atms.nc4)
-
 # Tests the global namelist files in the etc directory
 ADD_WRITER_TEST(NAME     varobswriter_globalnamelist_abiclr
                 YAML     varobswriter_globalnamelist_abiclr.yaml

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -315,6 +315,11 @@ ADD_WRITER_TEST(NAME     varobswriter_nested_output_directory
                 DATA     028_VarField_satid.nc4
                 DONT_SET_OPS_OUTPUT_DIR_ENV_VAR)
 
+# Tests on combined varobs and cx writer for global namelist
+ADD_WRITER_TEST(NAME     bothwriters_globalnamelist_atms
+                YAML     bothwriters_globalnamelist_atms.yaml
+                DATA     varobs_globalnamelist_atms.nc4)
+
 # Tests the global namelist files in the etc directory
 ADD_WRITER_TEST(NAME     varobswriter_globalnamelist_abiclr
                 YAML     varobswriter_globalnamelist_abiclr.yaml


### PR DESCRIPTION
This PR fixes #217 

In order to see how this affects the value of GeneralMode in the post filters there is a ctest in this branch.  There is no need to commit this ctest as it is not actually testing anything just adding a couple of print statements which need manually checking.

https://github.com/MetOffice/opsinputs/tree/feature/separateGenMode_withctest