### PR TITLE
Fix ifort truncated_source warning to error issue

### DIFF
--- a/deps/CMakeLists.txt
+++ b/deps/CMakeLists.txt
@@ -23,7 +23,7 @@ ${CMAKE_Fortran_DEBUG_FLAGS}"
   )
 elseif ("${CMAKE_Fortran_COMPILER_ID}" MATCHES "Intel")
   set(OPS_DEFAULT_Fortran_FLAGS "\
--warn alignments,errors,declarations,general,ignore_loc,nointerfaces,notruncated_source,shape,stderrors,uncalled,unused,usage \
+-warn alignments,declarations,errors,general,ignore_loc,nointerfaces,notruncated_source,shape,stderrors,uncalled,unused,usage \
 -implicitnone \
 -traceback \
 -integer-size 64 \

--- a/deps/CMakeLists.txt
+++ b/deps/CMakeLists.txt
@@ -23,10 +23,7 @@ ${CMAKE_Fortran_DEBUG_FLAGS}"
   )
 elseif ("${CMAKE_Fortran_COMPILER_ID}" MATCHES "Intel")
   set(OPS_DEFAULT_Fortran_FLAGS "\
--warn all \
--warn errors \
--warn notruncated_source \
--warn nointerfaces \
+-warn alignments,errors,declarations,general,ignore_loc,nointerfaces,notruncated_source,shape,stderrors,uncalled,unused,usage \
 -implicitnone \
 -traceback \
 -integer-size 64 \

--- a/deps/ops/CMakeLists.txt
+++ b/deps/ops/CMakeLists.txt
@@ -90,22 +90,8 @@ set(OPS_SOURCE_FILES
   stubs/OpsMod_Control/OpsMod_Control.f90
 )
 
-# Intel inserts lines in the source during pre-processing that contain the source file path, if the pathname
-# is long enough it can take the source line to more than 132 characters and trigger a compile warning.
-# If -warn errors is on this creates an invalid compile failure, so suppress this warning for these files to allow
-# compilation to proceed.
-if ("${CMAKE_Fortran_COMPILER_ID}" MATCHES "Intel")
-  set_source_files_properties(public/GenMod_Platform/GenMod_Platform.F90 PROPERTIES COMPILE_FLAGS "-warn noerrors")
-  set_source_files_properties(public/GenMod_Core/GenMod_Core.F90 PROPERTIES COMPILE_FLAGS "-warn noerrors")
-  set_source_files_properties(public/GenMod_Control/GenMod_Setup.F90 PROPERTIES COMPILE_FLAGS "-warn noerrors")
-  set_source_files_properties(public/Ops_Constants/GenMod_MiscUMScienceConstants.f90 PROPERTIES COMPILE_FLAGS "-warn noerrors")
-  set_source_files_properties(code/GenMod_ModelIO/GenMod_ModelIO.F90 PROPERTIES COMPILE_FLAGS "-warn noerrors")
-  set_source_files_properties(code/OpsMod_GatherSpread/OpsMod_GatherSpread.F90 PROPERTIES COMPILE_FLAGS "-warn noerrors")
-  set_source_files_properties(code/OpsProg_Utils/OpsProg_PrintCXFile.F90 PROPERTIES COMPILE_FLAGS "-warn noerrors")
-endif()
-
 # Collect the list of source directories (which will be added to the include path).
-foreach (file ${OPS_SOURCE_FILES})
+foreach(file ${OPS_SOURCE_FILES})
   get_filename_component(dir "${file}" DIRECTORY)
   list(APPEND OPS_SOURCE_DIRS "${dir}")
 endforeach()
@@ -142,10 +128,8 @@ target_compile_definitions(ops PRIVATE
   _LARGEFILE_SOURCE
 )
 
-if ("${CMAKE_Fortran_COMPILER_ID}" MATCHES "Intel")
-  target_compile_definitions(ops PRIVATE 
-    IFORT_ALLOCATABLE_CHARACTER_BUG
-  )
+if("${CMAKE_Fortran_COMPILER_ID}" MATCHES "Intel")
+  target_compile_definitions(ops PRIVATE IFORT_ALLOCATABLE_CHARACTER_BUG)
 endif()
 
 target_link_libraries(ops
@@ -192,10 +176,8 @@ target_compile_definitions(ops_serial PRIVATE
   _LARGEFILE_SOURCE
 )
 
-if ("${CMAKE_Fortran_COMPILER_ID}" MATCHES "Intel")
-  target_compile_definitions(ops_serial PRIVATE
-    IFORT_ALLOCATABLE_CHARACTER_BUG
-  )
+if("${CMAKE_Fortran_COMPILER_ID}" MATCHES "Intel")
+  target_compile_definitions(ops_serial PRIVATE IFORT_ALLOCATABLE_CHARACTER_BUG)
 endif()
 
 target_link_libraries(ops_serial


### PR DESCRIPTION
Explicitly list warn types, instead of all.