### PR TITLE
64bit options for Cray

### DIFF
--- a/deps/CMakeLists.txt
+++ b/deps/CMakeLists.txt
@@ -32,13 +32,11 @@ elseif ("${CMAKE_Fortran_COMPILER_ID}" MATCHES "Intel")
 -diag-disable 10121 \
 -assume norealloc_lhs \
 ${CMAKE_Fortran_FLAGS}"
-#-Wp,-P \
   )
 elseif ("${CMAKE_Fortran_COMPILER_ID}" MATCHES "Flang")
   set(OPS_DEFAULT_Fortran_FLAGS "\
 -fdefault-integer-8 -fdefault-real-8 \
 ${CMAKE_Fortran_FLAGS}"
-#-Wp,-P \
   )
   set(CMAKE_Fortran_DEBUG_FLAGS "\
 -check bounds \
@@ -51,13 +49,11 @@ elseif ("${CMAKE_Fortran_COMPILER_ID}" MATCHES "Cray")
   set(OPS_DEFAULT_Fortran_FLAGS "\
 -sdefault64 \
 ${CMAKE_Fortran_FLAGS}"
-#-Wp,-P \
   )
 elseif ("${CMAKE_Fortran_COMPILER_ID}" MATCHES "NAG")
   set(OPS_DEFAULT_Fortran_FLAGS "\
 -double \
 ${CMAKE_Fortran_FLAGS}"
-#-Wp,-P \
   )
   set(CMAKE_Fortran_DEBUG_FLAGS "\
 ${CMAKE_Fortran_DEBUG_FLAGS}"

--- a/deps/CMakeLists.txt
+++ b/deps/CMakeLists.txt
@@ -47,6 +47,12 @@ ${CMAKE_Fortran_FLAGS}"
 -check uninit \
 ${CMAKE_Fortran_DEBUG_FLAGS}"
   )
+elseif ("${CMAKE_Fortran_COMPILER_ID}" MATCHES "Cray")
+  set(OPS_DEFAULT_Fortran_FLAGS "\
+-sdefault64 \
+${CMAKE_Fortran_FLAGS}"
+#-Wp,-P \
+  )
 elseif ("${CMAKE_Fortran_COMPILER_ID}" MATCHES "NAG")
   set(OPS_DEFAULT_Fortran_FLAGS "\
 -double \

--- a/src/opsinputs/CMakeLists.txt
+++ b/src/opsinputs/CMakeLists.txt
@@ -47,9 +47,17 @@ elseif ("${CMAKE_Fortran_COMPILER_ID}" MATCHES "NAG")
   set(FORTRAN_FLAGS_64_BIT_TYPES "-double")
 elseif ("${CMAKE_Fortran_COMPILER_ID}" MATCHES "Flang")
   set(FORTRAN_FLAGS_64_BIT_TYPES "-fdefault-integer-8 -fdefault-real-8")
+elseif ("${CMAKE_Fortran_COMPILER_ID}" MATCHES "Cray")
+  set(FORTRAN_FLAGS_64_BIT_TYPES "-sdefault64")
 endif()
-set_source_files_properties(opsinputs_cxgenerate_mod.F90 PROPERTIES
-                            COMPILE_FLAGS "${FORTRAN_FLAGS_64_BIT_TYPES}")
+
+if ("${CMAKE_Fortran_COMPILER_ID}" MATCHES "Cray")
+  set_source_files_properties(opsinputs_cxgenerate_mod.F90 PROPERTIES
+                              COMPILE_OPTIONS "-sdefault64")
+else()
+  set_source_files_properties(opsinputs_cxgenerate_mod.F90 PROPERTIES
+                              COMPILE_FLAGS "${FORTRAN_FLAGS_64_BIT_TYPES}")
+endif()
 
 # In addition, we need to add the folder with these *.inc files to the
 # include path used when compiling that module.


### PR DESCRIPTION
Resolves #255.  This sets the relevant 64bit promotion for the Cray compiler, enabling compilation of those files that need these options.