### PR TITLE
Add defalut cx fields for MTG-IRS

### DIFF
--- a/deps/ops/stubs/OpsMod_CXGenerate/Ops_GetDefaultCxFields.inc
+++ b/deps/ops/stubs/OpsMod_CXGenerate/Ops_GetDefaultCxFields.inc
@@ -182,6 +182,11 @@ SELECT CASE (ObsGroup)
                        StashItem_qcl,StashItem_p,StashItem_p_surface,          &
                        StashCode_u10,StashCode_v10,StashCode_t2,StashCode_rh2, &
                        StashCode_pmsl/)
+  CASE (ObsGroupMTGIRS)
+    CxFields(1:14) = (/StashItem_theta,StashItem_q,StashItem_qcf,StashItem_SST,  &
+                       StashItem_SeaIce,StashItem_orog,StashItem_qcl,            &
+                       StashItem_p,StashItem_p_Surface,StashCode_u10,            &
+                       StashCode_v10,StashCode_t2,StashCode_rh2,StashCode_pmsl/)
   CASE (ObsGroupSatSST)
     CxFields(1:1) = (/AncilItem_SST/)
   CASE (ObsGroupAOD)


### PR DESCRIPTION
This PR adds a list of cx fields that are used as default for MTG-IRS. The mods are particularly useful when processing MTG-IRS in the UKV as for this model configuration there is no MTGIRS.nl file