### PR TITLE
Remove checks for old GCC versions

### DIFF
--- a/deps/gcom/CMakeLists.txt
+++ b/deps/gcom/CMakeLists.txt
@@ -2,11 +2,7 @@
 #
 
 if("${CMAKE_Fortran_COMPILER_ID}" MATCHES "GNU")
-  if("${CMAKE_Fortran_COMPILER_VERSION}" VERSION_GREATER "10.1.0")
-    set(GCOM_EXTRA_Fortran_FLAGS "-Wno-unused-dummy-argument -Wno-unused -fallow-argument-mismatch")
-  else()
-    set(GCOM_EXTRA_Fortran_FLAGS "-Wno-unused-dummy-argument -Wno-unused")
-  endif()
+  set(GCOM_EXTRA_Fortran_FLAGS "-Wno-unused-dummy-argument -Wno-unused -fallow-argument-mismatch")
 elseif("${CMAKE_Fortran_COMPILER_ID}" MATCHES "Intel")
   set(GCOM_EXTRA_Fortran_FLAGS "-warn nounused")
 endif()

--- a/deps/ops/CMakeLists.txt
+++ b/deps/ops/CMakeLists.txt
@@ -2,11 +2,7 @@
 #
 
 if("${CMAKE_Fortran_COMPILER_ID}" MATCHES "GNU")
-  if("${CMAKE_Fortran_COMPILER_VERSION}" VERSION_GREATER "10.1.0")
-    set(OPS_EXTRA_Fortran_FLAGS "-std=f2003 -fallow-argument-mismatch")
-  else()
-    set(OPS_EXTRA_Fortran_FLAGS "-std=f2003")
-  endif()
+  set(OPS_EXTRA_Fortran_FLAGS "-std=f2003 -fallow-argument-mismatch")
 elseif("${CMAKE_Fortran_COMPILER_ID}" MATCHES "Intel")
   set(OPS_EXTRA_Fortran_FLAGS "-stand f03")
 endif()


### PR DESCRIPTION
Fix #267.  Test output:

https://cylchub/services/cylc-review/taskjobs/david.davies/?suite=opsinputs-267