### PR TITLE
Add case default

### DIFF
--- a/src/opsinputs/opsinputs_cxwriter_mod.F90
+++ b/src/opsinputs/opsinputs_cxwriter_mod.F90
@@ -773,6 +773,8 @@ do i = 1, size(CxFields)
         write (DustBinIndexStr, '(i1)') DustBinIndex
         GeoVarName = opsinputs_cxfields_dustp_start // DustBinIndexStr // opsinputs_cxfields_dustp_end
       end if
+    case default
+      continue
 
   end select
 
@@ -1271,6 +1273,8 @@ do iCxField = 1, size(CxFields)
           opsinputs_cxfields_dustp_start // DustBinIndexStr // opsinputs_cxfields_dustp_end, &
           self % JediToOpsLayoutMapping, self % hofx, self % varnames)
       end if
+    case default
+      continue
   end select
 end do
 end subroutine opsinputs_cxwriter_populatecx

--- a/src/opsinputs/opsinputs_cxwriter_mod.F90
+++ b/src/opsinputs/opsinputs_cxwriter_mod.F90
@@ -599,6 +599,8 @@ integer                              :: i
 character(len=max_varname_length)    :: GeoVarName
 integer                              :: DustBinIndex
 character                            :: DustBinIndexStr
+character(len=80)                    :: ErrorMessage
+character(len=*), parameter          :: RoutineName = "opsinputs_cxwriter_addrequiredgeovars"
 
 ! Body:
 call Ops_ReadCXControlNL(self % obsgroup, CxFields, BGECall = .false._8, ops_call = .false._8)
@@ -774,6 +776,8 @@ do i = 1, size(CxFields)
         GeoVarName = opsinputs_cxfields_dustp_start // DustBinIndexStr // opsinputs_cxfields_dustp_end
       end if
     case default
+      write (ErrorMessage, '("Stash code not recognized: ",I0)') CxField
+      call gen_warn(RoutineName, ErrorMessage)
       continue
 
   end select
@@ -1274,6 +1278,8 @@ do iCxField = 1, size(CxFields)
           self % JediToOpsLayoutMapping, self % hofx, self % varnames)
       end if
     case default
+      write (ErrorMessage, '("Stash code not recognized: ",I0)') CxField
+      call gen_warn(RoutineName, ErrorMessage)
       continue
   end select
 end do

--- a/src/opsinputs/opsinputs_varobswriter_mod.F90
+++ b/src/opsinputs/opsinputs_varobswriter_mod.F90
@@ -606,6 +606,8 @@ type(oops_variables), intent(inout)      :: geovars
 ! Local declarations:
 integer(integer64)                       :: VarFields(ActualMaxVarfield)
 integer                                  :: i
+character(len=80)                        :: ErrorMessage
+character(len=*), parameter              :: RoutineName = "opsinputs_varobswriter_addrequiredgeovars"
 
 ! Body:
 call Ops_ReadVarobsControlNL(self % obsgroup, VarFields)
@@ -617,6 +619,8 @@ do i = 1, size(VarFields)
     ! here and in opsinputs_varobswriter_populateobservations.
     call geovars % push_back("land_type_index")
   case default
+    write (ErrorMessage, '("Varfield not recognized: ",I0)') VarFields(i)
+    call gen_warn(RoutineName, ErrorMessage)
     continue
   end select
 end do

--- a/src/opsinputs/opsinputs_varobswriter_mod.F90
+++ b/src/opsinputs/opsinputs_varobswriter_mod.F90
@@ -616,6 +616,8 @@ do i = 1, size(VarFields)
     ! TODO(someone): "land_type_index" may not be the right geoval to use. If it isn't, change it
     ! here and in opsinputs_varobswriter_populateobservations.
     call geovars % push_back("land_type_index")
+  case default
+    continue
   end select
 end do
 


### PR DESCRIPTION
Resolves #273.

This fix is semantically equivalent to the code in develop.  However it is probably not correct as looking at the relative select case blocks it looks like if the select falls through to the end and doesn't match anything it is probably an error and the code should abort.  This would be a change of behaviour and it might fail tests.  Let me know which you would prefer.