### PR TITLE
libopsinputs to link libops in PUBLIC mode

### DIFF
--- a/src/opsinputs/CMakeLists.txt
+++ b/src/opsinputs/CMakeLists.txt
@@ -73,7 +73,7 @@ ecbuild_add_library( TARGET   opsinputs
                      HEADER_DESTINATION ${INSTALL_INCLUDE_DIR}/opsinputs
                      LINKER_LANGUAGE ${OPSINPUTS_LINKER_LANGUAGE}
                      PRIVATE_INCLUDES ${OPS_INCLUDE_DIR} )
-target_link_libraries( opsinputs PUBLIC ufo ioda oops PRIVATE ops )
+target_link_libraries( opsinputs PUBLIC ufo ioda oops ops )
 
 ## Include paths
 target_include_directories(opsinputs PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src>


### PR DESCRIPTION
This should allow other projects to correctly build opsinputs with `add_subdirectory(/path/to/opsinputs EXCLUDE_FROM_ALL)`.