### PR TITLE
Changes needed for ufo pr 4112

### DIFF
--- a/src/opsinputs/CxWriter.cc
+++ b/src/opsinputs/CxWriter.cc
@@ -24,9 +24,9 @@
 namespace opsinputs {
 
 CxWriter::CxWriter(ioda::ObsSpace & obsdb, const Parameters_ & params,
-                   std::shared_ptr<ioda::ObsDataVector<int> > flags,
-                   std::shared_ptr<ioda::ObsDataVector<float> > obsErrors)
-  : obsdb_(obsdb), geovars_(), flags_(std::move(flags)), obsErrors_(std::move(obsErrors)),
+                   ioda::ObsDataVector<int> & flags,
+                   ioda::ObsDataVector<float> & obsErrors)
+  : obsdb_(obsdb), geovars_(), extradiagvars_(), flags_(flags), obsErrors_(obsErrors),
     parameters_(params)
 {
   oops::Log::trace() << "CxWriter constructor starting" << std::endl;
@@ -93,14 +93,14 @@ void CxWriter::postFilter(const ufo::GeoVaLs & gv,
     for (const ufo::Variable &var : parameters_.variables_for_qc.value().get())
       filtervars += var;
     ioda::ObsDataVector<int> flags(obsdb_, filtervars.toOopsObsVariables());
-    for (int ivar = 0; ivar < flags.nvars(); ivar++) {
+    for (size_t ivar = 0; ivar < flags.nvars(); ivar++) {
       const std::string varname = flags.varnames()[ivar];
-      flags[varname] = flags_->operator[](varname);
+      flags[varname] = flags_.operator[](varname);
     }
     opsinputs_cxwriter_post_f90(key_, obsdb_, gv.toFortran(), flags,
                                 hofx.nvars(), hofx.nlocs(), hofx.varnames(), &hofx.toFortran());
   } else {
-    opsinputs_cxwriter_post_f90(key_, obsdb_, gv.toFortran(), *flags_,
+    opsinputs_cxwriter_post_f90(key_, obsdb_, gv.toFortran(), flags_,
                                 hofx.nvars(), hofx.nlocs(), hofx.varnames(), &hofx.toFortran());
   }
 }

--- a/src/opsinputs/CxWriter.h
+++ b/src/opsinputs/CxWriter.h
@@ -51,8 +51,8 @@ class CxWriter : public ufo::ObsFilterBase,
   typedef CxWriterParameters Parameters_;
 
   CxWriter(ioda::ObsSpace &, const Parameters_ &,
-           std::shared_ptr<ioda::ObsDataVector<int> > flags,
-           std::shared_ptr<ioda::ObsDataVector<float> > obsErrors);
+           ioda::ObsDataVector<int> & flags,
+           ioda::ObsDataVector<float> & obsErrors);
   ~CxWriter();
 
   void preProcess() override {}
@@ -78,8 +78,8 @@ class CxWriter : public ufo::ObsFilterBase,
   ioda::ObsSpace & obsdb_;
   oops::Variables geovars_;
   oops::ObsVariables extradiagvars_;
-  std::shared_ptr<ioda::ObsDataVector<int>> flags_;
-  std::shared_ptr<ioda::ObsDataVector<float>> obsErrors_;
+  ioda::ObsDataVector<int> flags_;
+  ioda::ObsDataVector<float> obsErrors_;
 
   CxWriterParameters parameters_;
 };

--- a/src/opsinputs/CxWriter.h
+++ b/src/opsinputs/CxWriter.h
@@ -78,8 +78,8 @@ class CxWriter : public ufo::ObsFilterBase,
   ioda::ObsSpace & obsdb_;
   oops::Variables geovars_;
   oops::ObsVariables extradiagvars_;
-  ioda::ObsDataVector<int> flags_;
-  ioda::ObsDataVector<float> obsErrors_;
+  ioda::ObsDataVector<int> & flags_;
+  ioda::ObsDataVector<float> & obsErrors_;
 
   CxWriterParameters parameters_;
 };

--- a/src/opsinputs/VarObsWriter.cc
+++ b/src/opsinputs/VarObsWriter.cc
@@ -29,10 +29,10 @@
 namespace opsinputs {
 
 VarObsWriter::VarObsWriter(ioda::ObsSpace & obsdb, const Parameters_ & params,
-                           std::shared_ptr<ioda::ObsDataVector<int> > flags,
-                           std::shared_ptr<ioda::ObsDataVector<float> > obsErrors)
-  : obsdb_(obsdb), geovars_(), extradiagvars_(), flags_(std::move(flags)),
-    obsErrors_(std::move(obsErrors)), parameters_(params)
+                           ioda::ObsDataVector<int> & flags,
+                           ioda::ObsDataVector<float> & obsErrors)
+  : obsdb_(obsdb), geovars_(), extradiagvars_(), flags_(flags),
+    obsErrors_(obsErrors), parameters_(params)
 {
   oops::Log::trace() << "VarObsWriter constructor starting" << std::endl;
 
@@ -121,15 +121,15 @@ void VarObsWriter::postFilter(const ufo::GeoVaLs & gv,
     for (const ufo::Variable &var : parameters_.variables_for_qc.value().get())
       filtervars += var;
     ioda::ObsDataVector<int> flags(obsdb_, filtervars.toOopsObsVariables());
-    for (int ivar = 0; ivar < flags.nvars(); ivar++) {
+    for (size_t ivar = 0; ivar < flags.nvars(); ivar++) {
       std::string varname = flags.varnames()[ivar];
-      flags[varname] = flags_->operator[](varname);
+      flags[varname] = flags_.operator[](varname);
     }
-    opsinputs_varobswriter_post_f90(key_, obsdb_, flags, *obsErrors_,
+    opsinputs_varobswriter_post_f90(key_, obsdb_, flags, obsErrors_,
                                     hofx.nvars(), hofx.nlocs(), hofx.toFortran(),
                                     obsdiags.toFortran());
   } else {
-    opsinputs_varobswriter_post_f90(key_, obsdb_, *flags_, *obsErrors_,
+    opsinputs_varobswriter_post_f90(key_, obsdb_, flags_, obsErrors_,
                                     hofx.nvars(), hofx.nlocs(), hofx.toFortran(),
                                     obsdiags.toFortran());
   }

--- a/src/opsinputs/VarObsWriter.h
+++ b/src/opsinputs/VarObsWriter.h
@@ -60,8 +60,8 @@ class VarObsWriter : public ufo::ObsFilterBase,
   typedef VarObsWriterParameters Parameters_;
 
   VarObsWriter(ioda::ObsSpace &, const Parameters_ &,
-               std::shared_ptr<ioda::ObsDataVector<int> > flags,
-               std::shared_ptr<ioda::ObsDataVector<float> > obsErrors);
+               ioda::ObsDataVector<int> & flags,
+               ioda::ObsDataVector<float> & obsErrors);
   ~VarObsWriter();
 
   void preProcess() override {}
@@ -87,8 +87,8 @@ class VarObsWriter : public ufo::ObsFilterBase,
   ioda::ObsSpace & obsdb_;
   oops::Variables geovars_;
   oops::ObsVariables extradiagvars_;
-  std::shared_ptr<ioda::ObsDataVector<int>> flags_;
-  std::shared_ptr<ioda::ObsDataVector<float>> obsErrors_;
+  ioda::ObsDataVector<int> & flags_;
+  ioda::ObsDataVector<float> & obsErrors_;
   std::vector<int> varchannels_;
 
   VarObsWriterParameters parameters_;

--- a/test/opsinputs/CxChecker.cc
+++ b/test/opsinputs/CxChecker.cc
@@ -53,9 +53,9 @@ struct CxChecker::PrintCxFileOutput {
 
 
 CxChecker::CxChecker(ioda::ObsSpace & obsdb, const Parameters_ & params,
-                             std::shared_ptr<ioda::ObsDataVector<int> > flags,
-                             std::shared_ptr<ioda::ObsDataVector<float> > obsErrors)
-  : obsdb_(obsdb), geovars_(), flags_(std::move(flags)), obsErrors_(std::move(obsErrors)),
+                             ioda::ObsDataVector<int> & flags,
+                             ioda::ObsDataVector<float> & obsErrors)
+  : obsdb_(obsdb), geovars_(), flags_(flags), obsErrors_(obsErrors),
     parameters_(params)
 {
   oops::Log::trace() << "CxChecker constructor starting" << std::endl;

--- a/test/opsinputs/CxChecker.h
+++ b/test/opsinputs/CxChecker.h
@@ -58,8 +58,8 @@ class CxChecker : public ufo::ObsFilterBase,
   typedef CxCheckerParameters Parameters_;
 
   CxChecker(ioda::ObsSpace &, const Parameters_ &,
-            std::shared_ptr<ioda::ObsDataVector<int> > flags,
-            std::shared_ptr<ioda::ObsDataVector<float> > obsErrors);
+            ioda::ObsDataVector<int> & flags,
+            ioda::ObsDataVector<float> & obsErrors);
   ~CxChecker();
 
   void preProcess() override {}
@@ -96,8 +96,8 @@ class CxChecker : public ufo::ObsFilterBase,
   ioda::ObsSpace & obsdb_;
   oops::Variables geovars_;
   oops::ObsVariables extradiagvars_;
-  std::shared_ptr<ioda::ObsDataVector<int>> flags_;
-  std::shared_ptr<ioda::ObsDataVector<float>> obsErrors_;
+  ioda::ObsDataVector<int> & flags_;
+  ioda::ObsDataVector<float> & obsErrors_;
 
   CxCheckerParameters parameters_;
 };

--- a/test/opsinputs/ResetFlagsToPass.cc
+++ b/test/opsinputs/ResetFlagsToPass.cc
@@ -37,7 +37,7 @@ void ResetFlagsToPass::postFilter(const ufo::GeoVaLs &,
                                   const ufo::ObsDiagnostics &) {
   oops::Log::trace() << "ResetFlagsToPass postFilter" << std::endl;
   for (size_t v = 0; v < flags_.nvars(); ++v) {
-    ioda::ObsDataRow<int> &varflags = (flags_)[v];
+    ioda::ObsDataRow<int> &varflags = flags_[v];
     for (size_t i = 0; i < flags_.nlocs(); ++i)
       if (oops::contains(flagsToReset_, varflags[i]))
         varflags[i] = ufo::QCflags::pass;

--- a/test/opsinputs/ResetFlagsToPass.cc
+++ b/test/opsinputs/ResetFlagsToPass.cc
@@ -17,9 +17,9 @@ namespace opsinputs {
 namespace test {
 
 ResetFlagsToPass::ResetFlagsToPass(ioda::ObsSpace & obsdb, const Parameters_ & params,
-                                   std::shared_ptr<ioda::ObsDataVector<int> > flags,
-                                   std::shared_ptr<ioda::ObsDataVector<float> > /*obsErrors*/)
-  : obsdb_(obsdb), geovars_(), flags_(std::move(flags)), parameters_(params)
+                                   ioda::ObsDataVector<int> & flags,
+                                   ioda::ObsDataVector<float> & /*obsErrors*/)
+  : obsdb_(obsdb), geovars_(), flags_(flags), parameters_(params)
 {
   oops::Log::trace() << "ResetFlagsToPass constructor starting" << std::endl;
 
@@ -36,9 +36,9 @@ void ResetFlagsToPass::postFilter(const ufo::GeoVaLs &,
                                   const ioda::ObsVector &/*bias*/,
                                   const ufo::ObsDiagnostics &) {
   oops::Log::trace() << "ResetFlagsToPass postFilter" << std::endl;
-  for (size_t v = 0; v < flags_->nvars(); ++v) {
-    ioda::ObsDataRow<int> &varflags = (*flags_)[v];
-    for (size_t i = 0; i < flags_->nlocs(); ++i)
+  for (size_t v = 0; v < flags_.nvars(); ++v) {
+    ioda::ObsDataRow<int> &varflags = (flags_)[v];
+    for (size_t i = 0; i < flags_.nlocs(); ++i)
       if (oops::contains(flagsToReset_, varflags[i]))
         varflags[i] = ufo::QCflags::pass;
   }

--- a/test/opsinputs/ResetFlagsToPass.h
+++ b/test/opsinputs/ResetFlagsToPass.h
@@ -50,8 +50,8 @@ class ResetFlagsToPass : public ufo::ObsFilterBase,
   typedef ResetFlagsToPassParameters Parameters_;
 
   ResetFlagsToPass(ioda::ObsSpace &, const Parameters_ &,
-                   std::shared_ptr<ioda::ObsDataVector<int> > flags,
-                   std::shared_ptr<ioda::ObsDataVector<float> > obsErrors);
+                   ioda::ObsDataVector<int> & flags,
+                   ioda::ObsDataVector<float> & obsErrors);
   ~ResetFlagsToPass();
 
   void preProcess() override {}
@@ -71,7 +71,7 @@ class ResetFlagsToPass : public ufo::ObsFilterBase,
   ioda::ObsSpace & obsdb_;
   oops::Variables geovars_;
   oops::ObsVariables extradiagvars_;
-  std::shared_ptr<ioda::ObsDataVector<int>> flags_;
+  ioda::ObsDataVector<int> & flags_;
 
   ResetFlagsToPassParameters parameters_;
 

--- a/test/opsinputs/VarObsChecker.cc
+++ b/test/opsinputs/VarObsChecker.cc
@@ -75,9 +75,9 @@ struct VarObsChecker::PrintVarObsOutput {
 
 
 VarObsChecker::VarObsChecker(ioda::ObsSpace & obsdb, const Parameters_ & params,
-                             std::shared_ptr<ioda::ObsDataVector<int> > flags,
-                             std::shared_ptr<ioda::ObsDataVector<float> > obsErrors)
-  : obsdb_(obsdb), geovars_(), flags_(std::move(flags)), obsErrors_(std::move(obsErrors)),
+                             ioda::ObsDataVector<int> & flags,
+                             ioda::ObsDataVector<float> & obsErrors)
+  : obsdb_(obsdb), geovars_(), flags_(flags), obsErrors_(obsErrors),
     parameters_(params)
 {
   oops::Log::trace() << "VarObsChecker constructor starting" << std::endl;

--- a/test/opsinputs/VarObsChecker.h
+++ b/test/opsinputs/VarObsChecker.h
@@ -57,8 +57,8 @@ class VarObsChecker : public ufo::ObsFilterBase,
   typedef VarObsCheckerParameters Parameters_;
 
   VarObsChecker(ioda::ObsSpace &, const Parameters_ &,
-                std::shared_ptr<ioda::ObsDataVector<int> > flags,
-                std::shared_ptr<ioda::ObsDataVector<float> > obsErrors);
+                ioda::ObsDataVector<int> & flags,
+                ioda::ObsDataVector<float> & obsErrors);
   ~VarObsChecker();
 
   void preProcess() override {}
@@ -89,8 +89,8 @@ class VarObsChecker : public ufo::ObsFilterBase,
   ioda::ObsSpace & obsdb_;
   oops::Variables geovars_;
   oops::ObsVariables extradiagvars_;
-  std::shared_ptr<ioda::ObsDataVector<int>> flags_;
-  std::shared_ptr<ioda::ObsDataVector<float>> obsErrors_;
+  ioda::ObsDataVector<int> & flags_;
+  ioda::ObsDataVector<float> & obsErrors_;
 
   VarObsCheckerParameters parameters_;
 };


### PR DESCRIPTION
This PR is needed because of changes to pass the qc flags and errors as references rather than shared pointers in ufo, https://github.com/JCSDA-internal/ufo/pull/4112.

I have also added the explicit declaration of extradiagvars_ in the constructors as I think this is good practice.

This is a coordinated merge with the following prs:
- [ufo](https://github.com/JCSDA-internal/ufo/pull/4112)
- [oops](https://github.com/JCSDA-internal/oops/pull/3267)
- [pyiri](https://github.com/JCSDA-internal/pyiri-jedi/pull/174)
- [nemo-feedback](https://github.com/MetOffice/nemo-feedback/pull/82)

build-group=https://github.com/JCSDA-internal/oops/pull/3267
build-group=https://github.com/JCSDA-internal/pyiri-jedi/pull/174
build-group=https://github.com/MetOffice/nemo-feedback/pull/82
build-group=https://github.com/JCSDA-internal/ufo/pull/4112

The full mobundle testing has been run and output can be found here:
https://cylchub/services/cylc-review/cycles/michael.c.cooke/?suite=mobundle-ufo4112

The failure in ufo for the mo-bundle testing is a known problem with a ufo ctest and unrelated to this change:
https://cylchub/services/cylc-review/view/michael.c.cooke?&suite=mobundle-ufo4112&no_fuzzy_time=0&path=log/job/1/ctest_all_ufo__spice_gnu_debug/01/job.out#2106

Testing has been conducted with one of the sith kgo runs to show the change does not affect results:
https://cylchub/services/cylc-review/taskjobs/michael.c.cooke?&suite=sith_ufo4112%2Fkgo_glu&cycles=20210701T1200Z