### PR TITLE
Launch fewer CMake subprocesses

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,25 +1,14 @@
-# (C) Crown Copyright 2020, the Met Office. All rights reserved.
-#
+# (C) Crown Copyright Met Office. All rights reserved.
+cmake_minimum_required( VERSION 3.26 FATAL_ERROR )
+project( opsinputs VERSION 2026 LANGUAGES C CXX Fortran )
 
-################################################################################
-# opsinputs
-################################################################################
-
-cmake_minimum_required( VERSION 3.12 FATAL_ERROR )
-
-project( opsinputs VERSION 0.1 LANGUAGES C CXX Fortran )
 set( CMAKE_CXX_STANDARD 17 )
 set( CMAKE_CXX_STANDARD_REQUIRED ON )
 set( CMAKE_CXX_EXTENSIONS OFF )
-
 set( CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake;${CMAKE_MODULE_PATH} )
-
 set( CMAKE_DIRECTORY_LABELS "opsinputs" )
 
 set( ECBUILD_DEFAULT_BUILD_TYPE Release )
-set( ENABLE_OS_TESTS           OFF CACHE BOOL "Disable OS tests" FORCE )
-set( ENABLE_LARGE_FILE_SUPPORT OFF CACHE BOOL "Disable testing of large file support" FORCE )
-
 find_package( ecbuild 3.3.2 REQUIRED )
 include( ecbuild_system NO_POLICY_SCOPE )
 

--- a/cmake/opsinputs_functions.cmake
+++ b/cmake/opsinputs_functions.cmake
@@ -1,4 +1,4 @@
-# (C) Crown Copyright 2021, the Met Office. All rights reserved.
+# (C) Crown Copyright Met Office. All rights reserved.
 #
 #
 # Syntax: CREATE_SYMLINKS(src dst)
@@ -7,16 +7,14 @@
 # - src: Source folder
 # - dst: Destination folder
 #
-# Creates symbolic links in the destination folder pointing to the specified files in the source
-# folder, preserving subfolder hierarchy.
+# Creates symbolic links in the destination folder pointing to the specified
+# files in the source folder, preserving subfolder hierarchy.
 function(CREATE_SYMLINKS src dst)
   file(MAKE_DIRECTORY ${dst})
   foreach(FILENAME ${ARGN})
     get_filename_component(absolute_subdir ${src}/${FILENAME} DIRECTORY)
     file(RELATIVE_PATH relative_subdir ${src} ${absolute_subdir})
     file(MAKE_DIRECTORY ${dst}/${relative_subdir})
-    execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink
-                    ${src}/${FILENAME}
-                    ${dst}/${FILENAME})
+    file(CREATE_LINK ${src}/${FILENAME} ${dst}/${FILENAME} SYMBOLIC)
   endforeach()
 endfunction()


### PR DESCRIPTION
Similar to recent changes in JCSDA-internal repos.

- Replace `execute_process(... -E create_symlink ...)` with `file(CREATE_LINK ... SYMBOLIC)`.
- Bumps CMake version requirement to 3.26 to align with ops-um-jedi and mo-bundle.
- Update copyright statements and remove unnecessary variables.